### PR TITLE
Make gost-engine independent of OpenSSL SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,6 @@ else()
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DL_ENDIAN")
 endif()
 
-set(GOST_INCLUDE_DIRECTORIES "${OPENSSL_PATH}/include" "${OPENSSL_PATH}/crypto/include")
-
-set(GOST_LINK_DIRECTORIES "${OPENSSL_PATH}")
-
-include_directories("${GOST_INCLUDE_DIRECTORIES}")
-
 set(BIN_DIRECTORY bin)
 
 set(OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/${BIN_DIRECTORY})
@@ -93,8 +87,6 @@ set(GOST_ENGINE_SOURCE_FILES
         gost_md.c
         gost_md2012.c
         gost_pmeth.c)
-
-link_directories(${GOST_LINK_DIRECTORIES})
 
 add_library(gost STATIC ${GOST_LIB_SOURCE_FILES})
 set_target_properties(gost PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/CMake_ReadMe.md
+++ b/CMake_ReadMe.md
@@ -1,21 +1,25 @@
 ## CMake Config
 
-Required variables:
-1. `OPENSSL_PATH` - full path to local [openssl](https://github.com/openssl/openssl) source tree
+Configuring with `cmake` is can very simply be done like this:
 
-For Example:
-
-~~~bash
-cmake -DOPENSSL_PATH=/home/user/openssl .
+~~~ bash
+cmake .
 ~~~
 
-Build Example:
+If you want to build against a specific OpenSSL installation (if you have
+more than one, or your own private install, or...), you can use the `cmake`
+variable `CMAKE_C_FLAGS`:
 
-~~~bash
-cd ~/gost-engine
+~~~ bash
+cmake -DCMAKE_C_FLAGS='-I/PATH/TO/OPENSSL/include -L/PATH/TO/OPENSSL/lib' .
+~~~
+
+Build example:
+
+~~~ bash
 mkdir build
 cd build
-cmake -DOPENSSL_PATH=/home/user/openssl ..
+cmake -DCMAKE_C_FLAGS='-I/PATH/TO/OPENSSL/include -L/PATH/TO/OPENSSL/lib' ..
 make -j 8
 cd ../bin
 ~~~


### PR DESCRIPTION
It really already was, this only removes artifacts in CMakeLists.txt