### PR TITLE
Address compiler warnings and build with CMAKE_C_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 2.8)
 project(ccgost)
 
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+   message(STATUS "Using Clang and adding -Qunused-arguments flag")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments")
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c98 -O3 -Werror -Qunused-arguments -Wno-unused-function -Wno-missing-braces -Wall")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Werror -Wall -Qunused-arguments -Wno-unused-function -Wno-missing-braces -ggdb")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Werror -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces -ggdb")
 
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(ccgost)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c98 -O3 -Werror -Wall")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -Werror -ggdb")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c98 -O3 -Werror -Qunused-arguments -Wno-unused-function -Wno-missing-braces -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Werror -Wall -Qunused-arguments -Wno-unused-function -Wno-missing-braces -ggdb")
 
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
@@ -13,24 +13,6 @@ else()
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c98 -O3 -Werror -Wall")
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DL_ENDIAN")
 endif()
-
-# include and lib directories for OpenSSL
-set(GOST_INCLUDE_DIRECTORIES "${OPENSSL_PATH}/include")
-set(GOST_LINK_DIRECTORIES "${OPENSSL_PATH}/lib")
-
-# module linker flags
-SET (CMAKE_MODULE_LINKER_FLAGS "-L${OPENSSL_PATH}/lib" $ENV{LDFLAGS}
-     CACHE STRING "Flags used by the linker during the creation of modules.")
-# exe linker flags
-SET (CMAKE_EXE_LINKER_FLAGS "-L${OPENSSL_PATH}/lib" $ENV{LDFLAGS}
-     CACHE STRING "Flags used by the linker during the creation of executables.")
-# shared lib linker flags
-SET (CMAKE_SHARED_LINKER_FLAGS "-L${OPENSSL_PATH}/lib" $ENV{LDFLAGS}
-     CACHE STRING "Flags used by the linker during the creation of shared libraries.")
-
-
-include_directories("${GOST_INCLUDE_DIRECTORIES}")
-link_directories("${GOST_LINK_DIRECTORIES}")
 
 set(BIN_DIRECTORY bin)
 

--- a/gost12sum.c
+++ b/gost12sum.c
@@ -216,7 +216,7 @@ int hash_stream(gost_hash_ctx * ctx, int fd, char *sum)
     unsigned char buffer[BUF_SIZE];
     unsigned char reverted_buffer[BUF_SIZE];
     ssize_t bytes;
-    int i, j, k;
+
     start_hash12(ctx);
     while ((bytes = read(fd, buffer, BUF_SIZE)) > 0) {
         hash12_block(ctx, reverted_buffer, bytes);
@@ -225,7 +225,7 @@ int hash_stream(gost_hash_ctx * ctx, int fd, char *sum)
         return 0;
     }
     finish_hash12(ctx, buffer);
-    for (i = 0; i < (hashsize / 8); i++) {
+    for (size_t i = 0; i < (hashsize / 8); i++) {
         sprintf(sum + 2 * i, "%02x", buffer[i]);
     }
     return 1;

--- a/gost_ameth.c
+++ b/gost_ameth.c
@@ -641,11 +641,11 @@ static int pub_decode_gost_ec(EVP_PKEY *pk, X509_PUBKEY *pub)
     const unsigned char *pubkey_buf = NULL;
     unsigned char *databuf;
     ASN1_OBJECT *palgobj = NULL;
-    int pub_len, i, j;
+    int pub_len;
     EC_POINT *pub_key;
     BIGNUM *X, *Y;
     ASN1_OCTET_STRING *octet = NULL;
-    int len;
+    size_t len;
     const EC_GROUP *group;
 
     if (!X509_PUBKEY_get0_param(&palgobj, &pubkey_buf, &pub_len, &palg, pub))
@@ -698,8 +698,8 @@ static int pub_encode_gost_ec(X509_PUBKEY *pub, const EVP_PKEY *pk)
     ASN1_OBJECT *algobj = NULL;
     ASN1_OCTET_STRING *octet = NULL;
     void *pval = NULL;
-    unsigned char *buf = NULL, *databuf = NULL, *sptr;
-    int i, j, data_len, ret = -1;
+    unsigned char *buf = NULL, *databuf = NULL;
+    int data_len, ret = -1;
     const EC_POINT *pub_key;
     BIGNUM *X = NULL, *Y = NULL, *order = NULL;
     const EC_KEY *ec = EVP_PKEY_get0((EVP_PKEY *)pk);

--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -26,7 +26,6 @@ static int VKO_compute_key(unsigned char *shared_key, size_t shared_key_size,
     BIGNUM *UKM = NULL, *p = NULL, *order = NULL, *X = NULL, *Y = NULL;
     const BIGNUM *key = EC_KEY_get0_private_key(priv_key);
     EC_POINT *pnt = EC_POINT_new(EC_KEY_get0_group(priv_key));
-    int i;
     BN_CTX *ctx = BN_CTX_new();
     EVP_MD_CTX *mdctx = NULL;
     const EVP_MD *md = NULL;

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -526,7 +526,6 @@ int gost_grasshopper_cipher_cleanup(EVP_CIPHER_CTX* ctx) {
 int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX* ctx, ASN1_TYPE* params) {
     int len = 0;
     unsigned char* buf = NULL;
-    unsigned char* p = NULL;
     ASN1_OCTET_STRING* os = NULL;
 
     os = ASN1_OCTET_STRING_new();


### PR DESCRIPTION
Successfully tested with Clang-4.0, Clang from Xcode-8.3.3, GCC_6.3.0. Under cmake-3.8.2.

1. Fix compiler warnings. Only `gost_grasshopper_precompiled.c` still generates plenty of warnings.
2. Enabled build using GCC or Clang - cmake feeds the correct parameters automatically.