### PR TITLE
Migrate test framework to Test2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ os: linux
 
 language: c
 
+addons:
+  apt:
+    packages:
+    - cpanminus
+
 env:
   global:
     - PREFIX=${HOME}/opt
@@ -29,6 +34,7 @@ matrix:
 #      compiler: gcc
 
 before_script:
+  - sudo cpanm --notest Test2::V0 > build.log 2>&1 || (cat build.log && exit 1)
   - git clone --depth 1 -b ${OPENSSL_BRANCH} https://github.com/openssl/openssl.git
   - cd openssl
   - ./config shared -d --prefix=${PREFIX} --openssldir=${PREFIX} && make -j$(nproc) all && make install_sw > build.log 2>&1 || (cat build.log && exit 1)

--- a/test/00-engine.t
+++ b/test/00-engine.t
@@ -1,24 +1,25 @@
 #!/usr/bin/perl
-use Test::More tests => 7;
+use Test2::V0;
+plan(7);
 use Cwd 'abs_path';
 
 # prepare data for 
 
-open F,">","testdata.dat";
-print F "12345670" x 128;
-close F;
+open (my $F,">","testdata.dat");
+print $F "12345670" x 128;
+close $F;
 
 # Set OPENSSL_ENGINES environment variable to just built engine
 if(!defined $ENV{'OPENSSL_ENGINES'}){
 	$ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
 }
 
-$key='0123456789abcdef' x 2;
+my $key='0123456789abcdef' x 2;
 
 #
 # You can redefine engine to use using ENGINE_NAME environment variable
 # 
-$engine=$ENV{'ENGINE_NAME'}||"gost";
+my $engine=$ENV{'ENGINE_NAME'}||"gost";
 
 # Reopen STDERR to eliminate extra output
 open STDERR, ">>","tests.err";
@@ -32,6 +33,8 @@ if (exists $ENV{'OPENSSL_CONF'}) {
 # ${ENGINE_NAME}.info into this directory if you use this test suite
 # to test other engine implementing GOST cryptography.
 #
+my $engine_info;
+
 if ( -f $engine . ".info") {
 	diag("Reading $engine.info");
 	open F, "<", $engine . ".info";
@@ -54,8 +57,8 @@ is(`openssl dgst -engine $engine -md_gost94 testdata.dat`,
 "compute digest without config");
 
 
-open F,">","test.cnf";
-print F <<EOCFG;
+open $F,">","test.cnf";
+print $F <<EOCFG;
 openssl_conf = openssl_def
 [openssl_def]
 engines = engines
@@ -65,7 +68,7 @@ ${engine}=gost_conf
 default_algorithms = ALL
 
 EOCFG
-close F;
+close $F;
 $ENV{'OPENSSL_CONF'}=abs_path('test.cnf');
 
 is(`openssl engine -c $engine`,

--- a/test/01-digest.t
+++ b/test/01-digest.t
@@ -1,5 +1,6 @@
 #!/usr/bin/perl 
-use Test::More tests => 16;
+use Test2::V0;
+plan(16);
 use Cwd 'abs_path';
 
 # Set OPENSSL_ENGINES environment variable to just built engine
@@ -7,15 +8,16 @@ if(!defined $ENV{'OPENSSL_ENGINES'}){
         $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
 }
 # Set engine name from environment to allow testing of different engines
-$engine=$ENV{'ENGINE_NAME'}||"gost";
+my $engine=$ENV{'ENGINE_NAME'}||"gost";
 # Reopen STDERR to eliminate extra output
 open STDERR, ">>","tests.err";
 
 # prepare data for 
+my $F;
 
-open F,">","testm1.dat";
-print F "012345678901234567890123456789012345678901234567890123456789012";
-close F;
+open $F,">","testm1.dat";
+print $F "012345678901234567890123456789012345678901234567890123456789012";
+close $F;
 is(`openssl dgst -engine ${engine} -md_gost12_256 testm1.dat`,
 "md_gost12_256(testm1.dat)= 9d151eefd8590b89daa6ba6cb74af9275dd051026bb149a452fd84e5e57b5500\n",
 "GOST R 34.11-2012 256bit example 1 from standard");
@@ -26,9 +28,9 @@ is(`openssl dgst -engine ${engine} -md_gost12_512 testm1.dat`,
 
 unlink("testm1.dat");
 
-open F,">","testm2.dat";
-print F pack("H*","d1e520e2e5f2f0e82c20d1f2f0e8e1eee6e820e2edf3f6e82c20e2e5fef2fa20f120eceef0ff20f1f2f0e5ebe0ece820ede020f5f0e0e1f0fbff20efebfaeafb20c8e3eef0e5e2fb");
-close F;
+open $F,">","testm2.dat";
+print $F pack("H*","d1e520e2e5f2f0e82c20d1f2f0e8e1eee6e820e2edf3f6e82c20e2e5fef2fa20f120eceef0ff20f1f2f0e5ebe0ece820ede020f5f0e0e1f0fbff20efebfaeafb20c8e3eef0e5e2fb");
+close $F;
 is(`openssl dgst -engine ${engine} -md_gost12_256 testm2.dat`,
 "md_gost12_256(testm2.dat)= 9dd2fe4e90409e5da87f53976d7405b0c0cac628fc669a741d50063c557e8f50\n",
 "GOST R 34.11-2012 256bit example 2 from standard");
@@ -40,10 +42,10 @@ is(`openssl dgst -engine ${engine} -md_gost12_512 testm2.dat`,
 unlink("testm2.dat");
 
 
-open F,">","testdata.dat";
-binmode F;
-print F "12345670" x 128;
-close F;
+open $F,">","testdata.dat";
+binmode $F;
+print $F "12345670" x 128;
+close $F;
 is(`openssl dgst -engine ${engine} -md_gost94 testdata.dat`,
 "md_gost94(testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
 "GOST R 34.11-94 1K ascii");
@@ -58,10 +60,10 @@ is(`openssl dgst -engine ${engine} -md_gost12_512 testdata.dat`,
 
 unlink("testdata.dat");
 
-open F,">","testdata2.dat";
-binmode F;
-print F "\x00\x01\x02\x15\x84\x67\x45\x31" x 128;
-close F;
+open $F,">","testdata2.dat";
+binmode $F;
+print $F "\x00\x01\x02\x15\x84\x67\x45\x31" x 128;
+close $F;
 
 is(`openssl dgst -engine ${engine} -md_gost94 testdata2.dat`,
 "md_gost94(testdata2.dat)= 69f529aa82d9344ab0fa550cdf4a70ecfd92a38b5520b1906329763e09105196\n",
@@ -77,10 +79,10 @@ is(`openssl dgst -engine ${engine} -md_gost12_512 testdata2.dat`,
 
 unlink("testdata2.dat");
 
-open F, ">","testdata3.dat";
-binmode F;
-print F substr("12345670" x 128,0,539);
-close F;
+open $F, ">","testdata3.dat";
+binmode $F;
+print $F substr("12345670" x 128,0,539);
+close $F;
 
 is(`openssl dgst -engine ${engine} -md_gost94 testdata3.dat`,
 "md_gost94(testdata3.dat)= bd5f1e4b539c7b00f0866afdbc8ed452503a18436061747a343f43efe888aac9\n",
@@ -95,10 +97,10 @@ is(`openssl dgst -engine ${engine} -md_gost12_512 testdata3.dat`,
 "GOST R 34.11-2012 512bit 539 bytes");
 
 unlink "testdata3.dat";
-open F , ">","bigdata.dat";
-binmode F;
-print F  ("121345678" x 7 . "1234567\n") x 4096,"12345\n";
-close F;
+open $F , ">","bigdata.dat";
+binmode $F;
+print $F  ("121345678" x 7 . "1234567\n") x 4096,"12345\n";
+close $F;
 
 is(`openssl dgst -engine ${engine} -md_gost94 bigdata.dat`,
 "md_gost94(bigdata.dat)= e5d3ac4ea3f67896c51ff919cedb9405ad771e39f0f2eab103624f9a758e506f\n",

--- a/test/02-mac.t
+++ b/test/02-mac.t
@@ -1,24 +1,25 @@
 #!/usr/bin/perl 
-use Test::More tests => 19;
+use Test2::V0;
+plan(19);
 use Cwd 'abs_path';
 
 # prepare data for 
+my $F;
+open $F,">","testdata.dat";
+print $F "12345670" x 128;
+close $F;
 
-open F,">","testdata.dat";
-print F "12345670" x 128;
-close F;
-
-open F,">","testbig.dat";
-print F ("12345670" x 8 . "\n") x  4096;
-close F;
+open $F,">","testbig.dat";
+print $F ("12345670" x 8 . "\n") x  4096;
+close $F;
 # Set OPENSSL_ENGINES environment variable to just built engine
 if(!defined $ENV{'OPENSSL_ENGINES'}){
         $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
 }
 
-$key='0123456789abcdef' x 2;
+my $key='0123456789abcdef' x 2;
 
-$engine=$ENV{'ENGINE_NAME'}||"gost";
+my $engine=$ENV{'ENGINE_NAME'}||"gost";
 
 # Reopen STDERR to eliminate extra output
 open STDERR, ">>","tests.err";
@@ -27,6 +28,7 @@ is(`openssl dgst -engine ${engine} -mac gost-mac -macopt key:${key} testdata.dat
 "GOST-MAC-gost-mac(testdata.dat)= 2ee8d13d\n",
 "GOST MAC - default size");
 
+my $i;
 for ($i=1;$i<=8; $i++) {
 	is(`openssl dgst -engine ${engine} -mac gost-mac -macopt key:${key} -sigopt size:$i testdata.dat`,
 "GOST-MAC-gost-mac(testdata.dat)= ".substr("2ee8d13dff7f037d",0,$i*2)."\n",

--- a/test/03-encrypt.t
+++ b/test/03-encrypt.t
@@ -1,12 +1,13 @@
 #!/usr/bin/perl
-use Test::More tests => 48;
+use Test2::V0;
+plan(48);
 use Cwd 'abs_path';
 
 #
 # If this variable is set, engine would be loaded via configuration
 # file. Otherwise - via command line
 # 
-$use_config = 1;
+my $use_config = 1;
 
 # prepare data for 
 
@@ -16,12 +17,12 @@ if(!defined $ENV{'OPENSSL_ENGINES'}){
         $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
 }
 
-$key='0123456789abcdef' x 2;
+my $key='0123456789abcdef' x 2;
 
 #
 # You can redefine engine to use using ENGINE_NAME environment variable
 # 
-$engine=$ENV{'ENGINE_NAME'}||"gost";
+my $engine=$ENV{'ENGINE_NAME'}||"gost";
 
 # Reopen STDERR to eliminate extra output
 open STDERR, ">>","tests.err";
@@ -35,12 +36,14 @@ our $count=0;
 # -key - key (hex-encoded)
 # -iv  - IV (hex-encoded)
 # 
+my $F;
+my $eng_param;
 
-open F,">","test.cnf";
+open $F,">","test.cnf";
 if (defined($use_config) && $use_config) {
 	$eng_param = "";
-	open F,">","test.cnf";
-	print F <<EOCFG;
+	open $F,">","test.cnf";
+	print $F <<EOCFG
 openssl_conf = openssl_def
 [openssl_def]
 engines = engines
@@ -53,7 +56,7 @@ EOCFG
 } else {
 	$eng_param = "-engine $engine"
 }
-close F;
+close $F;
 $ENV{'OPENSSL_CONF'}=abs_path('test.cnf');
 	
 sub crypt_test {
@@ -67,7 +70,7 @@ sub crypt_test {
 	my $ctext = `openssl enc ${eng_param} -e -$p{-alg} -K $p{-key} -iv $p{-iv} -in test$count.clear`;
 	is($?,0,"$p{-name} - encrypt successful");
 	is(unpack("H*",$ctext),$p{-ciphertext},"$p{-name} - ciphertext expected");
-	open my $f, ">", "test$count.enc";
+	open $f, ">", "test$count.enc";
 	print $f $ctext;
 	close $f;
 	my $otext = `openssl enc ${eng_param} -d -$p{-alg} -K $p{-key} -iv $p{-iv} -in test$count.enc`;
@@ -79,8 +82,8 @@ sub crypt_test {
 }
 
 $key = '0123456789ABCDEF' x 4;
-$iv =  '0000000000000000';
-$clear1 = "The quick brown fox jumps over the lazy dog\n";
+my $iv =  '0000000000000000';
+my $clear1 = "The quick brown fox jumps over the lazy dog\n";
 
 crypt_test(-paramset=> "1.2.643.2.2.31.1", -key => $key, -iv => $iv,
 		   -cleartext => $clear1,

--- a/test/04-pkey.t
+++ b/test/04-pkey.t
@@ -1,12 +1,13 @@
 #!/usr/bin/perl
-use Test::More tests => 15;
+use Test2::V0;
+plan(15);
 use Cwd 'abs_path';
 
 #
 # If this variable is set, engine would be loaded via configuration
 # file. Otherwise - via command line
 # 
-$use_config = 1;
+my $use_config = 1;
 
 # prepare data for 
 
@@ -16,17 +17,19 @@ if(!defined $ENV{'OPENSSL_ENGINES'}){
         $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
 }
 
-$engine=$ENV{'ENGINE_NAME'}||"gost";
+my $engine=$ENV{'ENGINE_NAME'}||"gost";
 
 # Reopen STDERR to eliminate extra output
 open STDERR, ">>","tests.err";
 
+my $F;
+my $eng_param;
 
-open F,">","test.cnf";
+open $F,">","test.cnf";
 if (defined($use_config) && $use_config) {
 	$eng_param = "";
-	open F,">","test.cnf";
-	print F <<EOCFG;
+	open $F,">","test.cnf";
+	print $F <<EOCFG;
 openssl_conf = openssl_def
 [openssl_def]
 engines = engines
@@ -39,11 +42,11 @@ EOCFG
 } else {
 	$eng_param = "-engine $engine"
 }
-close F;
+close $F;
 $ENV{'OPENSSL_CONF'}=abs_path('test.cnf');
 
 
-@keys=(['gost2001','A',"-----BEGIN PRIVATE KEY-----
+my @keys=(['gost2001','A',"-----BEGIN PRIVATE KEY-----
 MEUCAQAwHAYGKoUDAgITMBIGByqFAwICIwEGByqFAwICHgEEIgIgRhUDJ1WQASIf
 nx+aUM2eagzV9dCt6mQ5wdtenr2ZS/Y=
 -----END PRIVATE KEY-----
@@ -119,20 +122,20 @@ ENjS+gA=
 -----END PUBLIC KEY-----
 ']
 );
-for $keyinfo (@keys) {
+for my $keyinfo (@keys) {
 	my ($alg,$paramset,$seckey,$sectext,$pubtext,$pubkey) = @$keyinfo;
-	open F,">",'tmp.pem';
-	print F $seckey;
-	close F;
+	open $F,">",'tmp.pem';
+	print $F $seckey;
+	close $F;
 	#1.  Прочитать секретный ключ и напечатать публичный и секретный ключи
 	is(`openssl pkey -noout -text -in tmp.pem`,$sectext . $pubtext,
 		"Print key pair $alg:$paramset");
 	#2. Прочитать секретный ключ и вывести публичный (все алгоритмы)
     is(`openssl pkey -pubout -in tmp.pem`,$pubkey,
 		"Compute public key $alg:$paramset");
-	open F,">","tmp.pem";
-	print F $pubkey;
-	close F;
+	open $F,">","tmp.pem";
+	print $F $pubkey;
+	close $F;
 	#3. Прочитать публичный и напечать его в виде текста
 	is(`openssl pkey -pubin -noout -in tmp.pem -text`,$pubtext,
 		"Read and print public key $alg:paramset");


### PR DESCRIPTION
At least Fedora 30 will have no Test::More anymore. Test::More is
deprecated, as well as Test::Stream and Test2 is a recommended
replacement.

Luckily, gost-engine's use of Test::More is limited to functions which
are compatible with implementations in Test2, so only module import and
test plan announcement need to change.