### PR TITLE
run_tests: pass OPENSSL_ROOT_DIR into perl tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,9 +155,10 @@ add_test(NAME gost89
 	COMMAND test_gost89)
 
 add_test(NAME engine
-	 COMMAND perl run_tests
-	 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
-set_tests_properties(engine PROPERTIES ENVIRONMENT OPENSSL_ENGINES=${OUTPUT_DIRECTORY})
+	COMMAND perl run_tests
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
+set_tests_properties(engine PROPERTIES ENVIRONMENT
+	"OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR};OPENSSL_ENGINES=${OUTPUT_DIRECTORY}")
 
 add_executable(sign benchmark/sign.c)
 target_link_libraries(sign gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 use TAP::Harness;
 
+if(defined $ENV{'OPENSSL_ROOT_DIR'} && !defined $ENV{'LD_LIBRARY_PATH'}) {
+  $ENV{'LD_LIBRARY_PATH'} = $ENV{'OPENSSL_ROOT_DIR'};
+  $ENV{'PATH'} = "$ENV{'OPENSSL_ROOT_DIR'}/apps:$ENV{'PATH'}";
+}
 my $harness = TAP::Harness->new();
 exit ($harness->runtests(glob("*.t"))->all_passed() ? 0 : 1);


### PR DESCRIPTION
If OPENSSL_ROOT_DIR is specified pass it to the perl tests, and set its
value as LD_LIBRARY_PATH, if unset. This allows to run tests for custom
openssl build without manually setting proper env.