### PR TITLE
 test_params: remove calls to internall API and add more tests

### DIFF
--- a/gost_eng.c
+++ b/gost_eng.c
@@ -164,7 +164,7 @@ static int gost_engine_destroy(ENGINE* e) {
     return 1;
 }
 
-int bind_gost(ENGINE* e, const char* id) {
+static int bind_gost(ENGINE* e, const char* id) {
     int ret = 0;
     if (id != NULL && strcmp(id, engine_gost_id) != 0)
         return 0;

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -301,7 +301,4 @@ int pack_sign_cp(ECDSA_SIG *s, int order, unsigned char *sig, size_t *siglen);
 /* Get private key as BIGNUM from both 34.10-2001 keys*/
 /* Returns pointer into EVP_PKEY structure */
 BIGNUM *gost_get0_priv_key(const EVP_PKEY *pkey);
-
-int bind_gost(ENGINE* e, const char* id);
-
 #endif


### PR DESCRIPTION
- Убрал вызов `fill_GOST_EC_params` и `bind_gost`.
- Дополнительные тесты.
