### PR TITLE
Fix leaks in tests

### DIFF
--- a/test_curves.c
+++ b/test_curves.c
@@ -191,6 +191,7 @@ static int parameter_test(struct test_curve *tc)
     BN_add(k2, k2, order);
     T(EC_POINT_mul(group, p1, NULL, generator, k1, ctx));
     T(EC_POINT_mul(group, p2, NULL, generator, k2, ctx));
+    T(EC_POINT_cmp(group, p1, p2, ctx) == 0);
 
     /* Cofactor is 1 or 4 */
     const BIGNUM *c;

--- a/test_curves.c
+++ b/test_curves.c
@@ -168,6 +168,15 @@ static int parameter_test(struct test_curve *tc)
     BN_mod_add(xxx, xxx, ax, p, ctx);
     BN_mod_add(xxx, xxx, b, p, ctx);
     T(BN_cmp(yy, xxx) == 0);
+    BN_free(yy);
+    BN_free(r);
+    BN_free(xxx);
+    BN_free(ax);
+    BN_free(p);
+    BN_free(a);
+    BN_free(b);
+    BN_free(x);
+    BN_free(y);
 
     /* Check order */
     const BIGNUM *order;
@@ -180,6 +189,7 @@ static int parameter_test(struct test_curve *tc)
     T(EC_POINT_mul(group, point, NULL, generator, order, ctx));
     /* generator * order is the point at infinity? */
     T(EC_POINT_is_at_infinity(group, point) == 1);
+    EC_POINT_free(point);
 
     /* Check if order is cyclic */
     BIGNUM *k1 = BN_new();
@@ -192,12 +202,18 @@ static int parameter_test(struct test_curve *tc)
     T(EC_POINT_mul(group, p1, NULL, generator, k1, ctx));
     T(EC_POINT_mul(group, p2, NULL, generator, k2, ctx));
     T(EC_POINT_cmp(group, p1, p2, ctx) == 0);
+    BN_free(k1);
+    BN_free(k2);
+    EC_POINT_free(p1);
+    EC_POINT_free(p2);
 
     /* Cofactor is 1 or 4 */
     const BIGNUM *c;
     T(c = EC_GROUP_get0_cofactor(group));
     T(BN_is_word(c, 1) || BN_is_word(c, 4));
 
+    BN_CTX_free(ctx);
+    EC_KEY_free(ec);
     TEST_ASSERT(0);
     return test;
 }

--- a/test_params.c
+++ b/test_params.c
@@ -949,6 +949,8 @@ static int test_cert(struct test_cert *tc)
     EVP_MD_CTX_free(md_ctx);
     ret |= err != 1;
 
+    X509_free(x);
+    OPENSSL_free(tbs);
     return ret;
 }
 
@@ -1045,6 +1047,7 @@ static int test_param(struct test_param *t)
     printf("  EVP_PKEY_verify API\t\t");
     T(EVP_PKEY_verify_init(ctx));
     err = EVP_PKEY_verify(ctx, sig, siglen, t->hash, t->len);
+    EVP_PKEY_CTX_free(ctx);
     print_test_result(err);
     ret |= err != 1;
 
@@ -1082,6 +1085,7 @@ static int test_param(struct test_param *t)
     }
 
     OPENSSL_free(sig);
+    EVP_PKEY_free(pkey);
     return ret;
 }
 

--- a/test_sign.c
+++ b/test_sign.c
@@ -226,6 +226,8 @@ static int test_sign(struct test_sign *t)
     EVP_PKEY_CTX_free(ctx);
     OPENSSL_free(sig);
     OPENSSL_free(hash);
+    EVP_PKEY_free(priv_key);
+    EVP_PKEY_free(key2);
 
     return ret;
 }


### PR DESCRIPTION
In preparation for memory leak detector fix them in the tests.
Add forgotten comparison in test_curves.