### PR TITLE
tests: Load just built engine from the output directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,18 @@ endif()
 add_executable(sign benchmark/sign.c)
 target_link_libraries(sign gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY} ${CLOCK_GETTIME_LIB})
 
+# All that may need to load just built engine will have path to it defined.
+set(BINARY_TESTS_TARGETS
+        test_curves
+        test_params
+        test_sign
+        test_context
+        test_grasshopper
+        test_keyexpimp
+        test_gost89
+        )
+set_property(TARGET ${BINARY_TESTS_TARGETS} APPEND PROPERTY COMPILE_DEFINITIONS ENGINE_DIR="${OUTPUT_DIRECTORY}")
+
 add_library(gost_core STATIC ${GOST_LIB_SOURCE_FILES})
 set_target_properties(gost_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/test_curves.c
+++ b/test_curves.c
@@ -222,10 +222,21 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
+    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
+    OPENSSL_add_all_algorithms_conf();
+    ERR_load_crypto_strings();
+    ENGINE *eng;
+    T(eng = ENGINE_by_id("gost"));
+    T(ENGINE_init(eng));
+    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
+
     struct test_curve *tc;
     for (tc = test_curves; tc->nid; tc++) {
 	ret |= parameter_test(tc);
     }
+
+    ENGINE_finish(eng);
+    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);

--- a/test_params.c
+++ b/test_params.c
@@ -1093,9 +1093,13 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_CONF", "../example.conf", 0);
+    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
     ERR_load_crypto_strings();
+    ENGINE *eng;
+    T(eng = ENGINE_by_id("gost"));
+    T(ENGINE_init(eng));
+    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     struct test_param **tpp;
     for (tpp = test_params; *tpp; tpp++)
@@ -1104,6 +1108,9 @@ int main(int argc, char **argv)
     struct test_cert *tc;
     for (tc = test_certs; tc->cert; tc++)
 	ret |= test_cert(tc);
+
+    ENGINE_finish(eng);
+    ENGINE_free(eng);
 
     return ret;
 }

--- a/test_sign.c
+++ b/test_sign.c
@@ -236,13 +236,20 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_CONF", "../example.conf", 0);
+    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
     ERR_load_crypto_strings();
+    ENGINE *eng;
+    T(eng = ENGINE_by_id("gost"));
+    T(ENGINE_init(eng));
+    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     struct test_sign *sp;
     for (sp = test_signs; sp->name; sp++)
 	ret |= test_sign(sp);
+
+    ENGINE_finish(eng);
+    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);


### PR DESCRIPTION
Define ENGINE_DIR for all binary tests. Instead of auto-loading engine
using `example.conf' load it directly from the OUTPUT_DIRECTORY for
curves tests.