### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/test_tls.c
+++ b/test_tls.c
@@ -26,6 +26,7 @@
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <err.h>
 


### PR DESCRIPTION
Otherwise `struct sockaddr_in` is undefined for test_tls.

Reported in #123 by f-andrey.