### PR TITLE
travis-ci: cleanup "so/dylib" mangling, not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,4 @@ script:
   - cd build
   - cmake -DOPENSSL_ROOT_DIR=${PREFIX} -DOPENSSL_LIBRARIES=${PREFIX}/lib -DOPENSSL_ENGINES_DIR=${PREFIX}/engines ${ASAN} ..
   - make
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then cp bin/gost.{dylib,so}; fi # this hack is most probably related to https://github.com/openssl/openssl/issues/727
   - make test CTEST_OUTPUT_ON_FAILURE=1


### PR DESCRIPTION
after https://github.com/openssl/openssl/pull/8951