### PR TITLE
Fix test_grasshopper and test_keyexpimp engine init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
 
 
 before_script:
+  - curl -L https://cpanmin.us | sudo perl - --sudo App::cpanminus
   - sudo cpanm --notest Test2::V0 > build.log 2>&1 || (cat build.log && exit 1)
   - git clone --depth 1 -b ${OPENSSL_BRANCH} https://github.com/openssl/openssl.git
   - cd openssl


### PR DESCRIPTION
Make proper engine initialization for tests instead of
EVP_add_cipher/EVP_add_digest hack. Fixes #151.