### PR TITLE
test/run_tests: Always set paths when OPENSSL_ROOT_DIR is defined

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ FreeBSD_task:
     PATH: ${PREFIX}/bin:${PATH}
     OPENSSL_BRANCH: master
   script:
-    - pkg install git cmake p5-App-cpanminus gdb
+    - pkg install git cmake p5-App-cpanminus gdb pkgconf
     - sudo cpanm --notest Test2::V0
     - git clone --depth 1 -b ${OPENSSL_BRANCH} https://github.com/openssl/openssl.git
     - cd openssl

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,9 +1,37 @@
 #!/usr/bin/perl
 use TAP::Harness;
 
-if(defined $ENV{'OPENSSL_ROOT_DIR'} && !defined $ENV{'LD_LIBRARY_PATH'}) {
-  $ENV{'LD_LIBRARY_PATH'} = $ENV{'OPENSSL_ROOT_DIR'};
-  $ENV{'PATH'} = "$ENV{'OPENSSL_ROOT_DIR'}/apps:$ENV{'PATH'}";
+if(defined $ENV{'OPENSSL_ROOT_DIR'}) {
+    my $openssl_libdir;
+    my $openssl_bindir;
+
+    if (-d "$ENV{'OPENSSL_ROOT_DIR'}/apps") {
+        # The OpenSSL root dir is an OpenSSL build tree
+        $openssl_bindir = "$ENV{'OPENSSL_ROOT_DIR'}/apps";
+        $openssl_libdir = "$ENV{'OPENSSL_ROOT_DIR'}";
+    } else {
+        # The OpenSSL root dir is an OpenSSL installation tree
+        # Since we're not exactly sure what the library path is (because
+        # multilib), we ask pkg-config
+        local $ENV{PKG_CONFIG_PATH} = "$ENV{'OPENSSL_ROOT_DIR'}/lib/pkgconfig";
+        my $pkgans = `pkg-config --libs-only-L openssl`;
+
+        # If pkg-config failed for any reason, abort.  The tests will most
+        # likely fail anyway because the binary path won't have a matching
+        # library path.
+        die "pkg-config failure: $! (exit code ", $? >> 8, ", signal ", $? & 0xff, ")"
+            if ($? != 0);
+
+        $pkgans =~ s|\R$||;      # Better chomp
+        $pkgans =~ s|^-L||;      # Remove flag from answer
+
+        $openssl_libdir = $pkgans;
+        $openssl_bindir = "$ENV{'OPENSSL_ROOT_DIR'}/bin";
+    }
+    $ENV{'LD_LIBRARY_PATH'} =
+        join(':', $openssl_libdir, split(/:/, $ENV{'LD_LIBRARY_PATH'}));
+    $ENV{'PATH'} =
+        join(':', $openssl_bindir, split(/:/, $ENV{'PATH'}));
 }
 my $harness = TAP::Harness->new();
 exit ($harness->runtests(glob("*.t"))->all_passed() ? 0 : 1);


### PR DESCRIPTION
When the environment variable OPENSSL_ROOT_DIR is defined, we need to
ensure that PATH and LD_LIBRARY_PATH are properly affected.

This is a little bit complicated, since OPENSSL_ROOT_DIR could point
at an OpenSSL build directory as well as an OpenSSL installation
tree.  Fortunately, it's easy to detect the difference; if it's a
build tree, there's a sub-directory 'apps'.

For installation trees, it's further complicated by OpenSSL's
'multilib' target attribute, which exists for platforms that support
directory separated libraries for differing bitness (typically 32-bit
and 64-bit libraries).  We trust pkg-config to give us the answer.
Binaries are easier, they live in $OPENSL_ROOT_DIR/bin.

Fixes #146