### PR TITLE
Cleanup tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ add_test(NAME engine
 	COMMAND perl run_tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
 set_tests_properties(engine PROPERTIES ENVIRONMENT
-	"OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR};OPENSSL_ENGINES=${OUTPUT_DIRECTORY}")
+	"OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR};OPENSSL_ENGINES=${OUTPUT_DIRECTORY};OPENSSL_CONF=${CMAKE_SOURCE_DIR}/test/empty.cnf")
 endif()
 
 add_executable(sign benchmark/sign.c)

--- a/test/00-engine.t
+++ b/test/00-engine.t
@@ -9,11 +9,6 @@ open (my $F,">","testdata.dat");
 print $F "12345670" x 128;
 close $F;
 
-# Set OPENSSL_ENGINES environment variable to just built engine
-if(!defined $ENV{'OPENSSL_ENGINES'}){
-	$ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
-}
-
 my $key='0123456789abcdef' x 2;
 
 #

--- a/test/01-digest.t
+++ b/test/01-digest.t
@@ -1,12 +1,7 @@
 #!/usr/bin/perl 
 use Test2::V0;
 plan(16);
-use Cwd 'abs_path';
 
-# Set OPENSSL_ENGINES environment variable to just built engine
-if(!defined $ENV{'OPENSSL_ENGINES'}){
-        $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
-}
 # Set engine name from environment to allow testing of different engines
 my $engine=$ENV{'ENGINE_NAME'}||"gost";
 # Reopen STDERR to eliminate extra output

--- a/test/02-mac.t
+++ b/test/02-mac.t
@@ -1,7 +1,6 @@
 #!/usr/bin/perl 
 use Test2::V0;
 plan(19);
-use Cwd 'abs_path';
 
 # prepare data for 
 my $F;
@@ -12,10 +11,6 @@ close $F;
 open $F,">","testbig.dat";
 print $F ("12345670" x 8 . "\n") x  4096;
 close $F;
-# Set OPENSSL_ENGINES environment variable to just built engine
-if(!defined $ENV{'OPENSSL_ENGINES'}){
-        $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
-}
 
 my $key='0123456789abcdef' x 2;
 

--- a/test/03-encrypt.t
+++ b/test/03-encrypt.t
@@ -11,12 +11,6 @@ my $use_config = 1;
 
 # prepare data for 
 
-
-# Set OPENSSL_ENGINES environment variable to just built engine
-if(!defined $ENV{'OPENSSL_ENGINES'}){
-        $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
-}
-
 my $key='0123456789abcdef' x 2;
 
 #

--- a/test/04-pkey.t
+++ b/test/04-pkey.t
@@ -12,11 +12,6 @@ my $use_config = 1;
 # prepare data for 
 
 
-# Set OPENSSL_ENGINES environment variable to just built engine
-if(!defined $ENV{'OPENSSL_ENGINES'}){
-        $ENV{'OPENSSL_ENGINES'} = abs_path("../.libs");
-}
-
 my $engine=$ENV{'ENGINE_NAME'}||"gost";
 
 # Reopen STDERR to eliminate extra output


### PR DESCRIPTION
Have CMakeLists.txt specify a value for the env var `OPENSSL_CONF`.  This will ensure a value from the user's environment won't cause trouble with the tests.  Also, don't set `OPENSSL_ENGINES` in the .t scripts, and especially not to a bogus value.