### PR TITLE
For Grasshopper OMAC_ACPKM, OMAC and MAGMA, support XOF

### DIFF
--- a/gost_omac.c
+++ b/gost_omac.c
@@ -203,6 +203,7 @@ int omac_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
             return 0;
         }
     case EVP_MD_CTRL_MAC_LEN:
+    case EVP_MD_CTRL_XOF_LEN:   /* Supported in OpenSSL */
         {
             OMAC_CTX *c = EVP_MD_CTX_md_data(ctx);
             switch (c->cipher_nid) {
@@ -257,7 +258,7 @@ EVP_MD *magma_omac(void)
             || !EVP_MD_meth_set_result_size(md, 8)
             || !EVP_MD_meth_set_input_blocksize(md, 8)
             || !EVP_MD_meth_set_app_datasize(md, sizeof(OMAC_CTX))
-            || !EVP_MD_meth_set_flags(md, 0)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
             || !EVP_MD_meth_set_init(md, magma_imit_init)
             || !EVP_MD_meth_set_update(md, omac_imit_update)
             || !EVP_MD_meth_set_final(md, omac_imit_final)
@@ -289,7 +290,7 @@ EVP_MD *grasshopper_omac(void)
             || !EVP_MD_meth_set_result_size(md, 16)
             || !EVP_MD_meth_set_input_blocksize(md, 8)
             || !EVP_MD_meth_set_app_datasize(md, sizeof(OMAC_CTX))
-            || !EVP_MD_meth_set_flags(md, 0)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
             || !EVP_MD_meth_set_init(md, grasshopper_imit_init)
             || !EVP_MD_meth_set_update(md, omac_imit_update)
             || !EVP_MD_meth_set_final(md, omac_imit_final)

--- a/gost_omac_acpkm.c
+++ b/gost_omac_acpkm.c
@@ -466,6 +466,7 @@ int omac_acpkm_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
             return 1;
         }
     case EVP_MD_CTRL_MAC_LEN:
+    case EVP_MD_CTRL_XOF_LEN:   /* Supported in OpenSSL */
         {
             OMAC_ACPKM_CTX *c = EVP_MD_CTX_md_data(ctx);
             switch (c->cipher_nid) {
@@ -507,7 +508,7 @@ EVP_MD *grasshopper_omac_acpkm(void)
             || !EVP_MD_meth_set_result_size(md, MAX_GOST_OMAC_ACPKM_SIZE)
             || !EVP_MD_meth_set_input_blocksize(md, GRASSHOPPER_BLOCK_SIZE)
             || !EVP_MD_meth_set_app_datasize(md, sizeof(OMAC_ACPKM_CTX))
-            || !EVP_MD_meth_set_flags(md, 0)
+            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
             || !EVP_MD_meth_set_init(md, grasshopper_omac_acpkm_init)
             || !EVP_MD_meth_set_update(md, omac_acpkm_imit_update)
             || !EVP_MD_meth_set_final(md, omac_acpkm_imit_final)


### PR DESCRIPTION
XOF (eXtendable-Output Function) is supported in OpenSSL since version
1.1.1.  Unfortunately, that support is limited, as it requires calling
EVP_DigestFinalXOF().  However, the grasshopper code wasn't compatible.

This changeset adds XOF support in grasshopper

This changeset removes the _meth_ calls from test_grasshopper.c (they
should never have been there, but considering support for XOF came so
late in OpenSSL, their presence is understandable) and uses supported
functionality for this sort of thing instead.