### PR TITLE
Fixes for Scan 20190918

### DIFF
--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -59,8 +59,11 @@ int VKO_compute_key(unsigned char *shared_key,
         GOSTerr(GOST_F_VKO_COMPUTE_KEY, GOST_R_ERROR_POINT_MUL);
         goto err;
     }
-    EC_POINT_get_affine_coordinates(EC_KEY_get0_group(priv_key),
-                                        pnt, X, Y, ctx);
+    if (!EC_POINT_get_affine_coordinates(EC_KEY_get0_group(priv_key),
+                                        pnt, X, Y, ctx)) {
+	GOSTerr(GOST_F_VKO_COMPUTE_KEY, ERR_R_EC_LIB);
+	goto err;
+    }
 
     half_len = BN_num_bytes(order);
     buf_len = 2 * half_len;

--- a/test_grasshopper.c
+++ b/test_grasshopper.c
@@ -299,8 +299,8 @@ static int test_stream(const EVP_CIPHER *type, const char *name,
 	int i;
 
 	EVP_CIPHER_CTX_init(ctx);
-	EVP_CipherInit_ex(ctx, type, NULL, K, iv, 1);
-	EVP_CIPHER_CTX_set_padding(ctx, 0);
+	T(EVP_CipherInit_ex(ctx, type, NULL, K, iv, 1));
+	T(EVP_CIPHER_CTX_set_padding(ctx, 0));
 	memset(c, 0xff, sizeof(c));
 	if (acpkm)
 	    T(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_KEY_MESH, acpkm, NULL));
@@ -309,11 +309,11 @@ static int test_stream(const EVP_CIPHER *type, const char *name,
 		sz = size - i;
 	    else
 		sz = z;
-	    EVP_CipherUpdate(ctx, c + i, &outlen, pt + i, sz);
+	    T(EVP_CipherUpdate(ctx, c + i, &outlen, pt + i, sz));
 	    OPENSSL_assert(outlen == sz);
 	}
 	outlen = i - z + sz;
-	EVP_CipherFinal_ex(ctx, c + outlen, &tmplen);
+	T(EVP_CipherFinal_ex(ctx, c + outlen, &tmplen));
 	EVP_CIPHER_CTX_cleanup(ctx);
 
 	test = outlen != size || memcmp(c, exp, size);


### PR DESCRIPTION
test_grasshopper: Fix CIDs 253281, 253280, 253279, 253275
gost_ec_keyx: Fix CID 253283 Unchecked return value in VKO_compute_key 