### PR TITLE
ameth: fill digestParamSet for the sake of backwards compatibility

### DIFF
--- a/gost_ameth.c
+++ b/gost_ameth.c
@@ -79,6 +79,12 @@ static ASN1_STRING *encode_gost_algor_params(const EVP_PKEY *key)
         break;
     case NID_id_GostR3410_2012_512:
         pkey_param_nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(key_ptr));
+	switch (pkey_param_nid) {
+	    case NID_id_tc26_gost_3410_2012_512_paramSetTest:
+	    case NID_id_tc26_gost_3410_2012_512_paramSetA:
+	    case NID_id_tc26_gost_3410_2012_512_paramSetB:
+		gkp->hash_params = OBJ_nid2obj(NID_id_GostR3411_2012_512);
+	}
         break;
     case NID_id_GostR3410_2001:
         pkey_param_nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(key_ptr));


### PR DESCRIPTION
Even though it is not recommended by R 1323565.1.023-2018 fill
digestParamSet field for 512-bit curves Test, TC26-A, TC26-B because old
cryptoproviders expect this field to be present.

Signed-off-by: Dmitry Eremin-Solenikov <dbaryshkov@gmail.com>