### PR TITLE
fix .travis.yml. make test against openssl-stable 1.1.1   

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PREFIX=${HOME}/opt
     - PATH=${PREFIX}/bin:${PATH}
-    - OPENSSL_BRANCH=master
+    - OPENSSL_BRANCH=OpenSSL_1_1_1-stable
 
 matrix:
   include:


### PR DESCRIPTION
master branch of parent OpenSSL project switched to 3.x version. To pass travis tests OpenSSL GOST engine require OpenSSL version 1.1.1.