### PR TITLE
PR example of Dulesov Streebog optimizations

### DIFF
--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -35,10 +35,15 @@ void init_gost2012_hash_ctx(gost2012_hash_ctx * CTX,
     memset(CTX, 0, sizeof(gost2012_hash_ctx));
 
     CTX->digest_size = digest_size;
+    /*
+     * IV for 512-bit hash should be 0^512
+     * IV for 256-bit hash should be (00000001)^64
+     *
+     * It's already zeroed when CTX is cleared above, so we only
+     * need to set it to 0x01-s for 256-bit hash.
+     */
     if (digest_size == 256)
         memset(&CTX->h, 0x01, sizeof(uint512_u));
-    else
-        memset(&CTX->h, 0x00, sizeof(uint512_u));
 }
 
 static INLINE void pad(gost2012_hash_ctx * CTX)

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -192,7 +192,6 @@ static INLINE void stage3(gost2012_hash_ctx * CTX)
     g(&(CTX->h), &buffer0, (const unsigned char *)&(CTX->N));
 
     g(&(CTX->h), &buffer0, (const unsigned char *)&(CTX->Sigma));
-    memcpy(&(CTX->hash), &(CTX->h), sizeof(uint512_u));
 }
 
 /*
@@ -242,7 +241,7 @@ void gost2012_finish_hash(gost2012_hash_ctx * CTX, unsigned char *digest)
     CTX->bufsize = 0;
 
     if (CTX->digest_size == 256)
-        memcpy(digest, &(CTX->hash.QWORD[4]), 32);
+        memcpy(digest, &(CTX->h.QWORD[4]), 32);
     else
-        memcpy(digest, &(CTX->hash.QWORD[0]), 64);
+        memcpy(digest, &(CTX->h.QWORD[0]), 64);
 }

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -48,13 +48,9 @@ void init_gost2012_hash_ctx(gost2012_hash_ctx * CTX,
 
 static INLINE void pad(gost2012_hash_ctx * CTX)
 {
-    unsigned char buf[64];
+    memset(&(CTX->buffer[CTX->bufsize]), 0, sizeof(CTX->buffer) - CTX->bufsize);
+    CTX->buffer[CTX->bufsize] = 1;
 
-    memset(&buf, 0x00, sizeof buf);
-    memcpy(&buf, CTX->buffer, CTX->bufsize);
-
-    buf[CTX->bufsize] = 0x01;
-    memcpy(CTX->buffer, &buf, sizeof buf);
 }
 
 static INLINE void add512(const union uint512_u *x,

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -158,28 +158,19 @@ static INLINE void stage2(gost2012_hash_ctx * CTX, const union uint512_u *data)
 
 static INLINE void stage3(gost2012_hash_ctx * CTX)
 {
-    ALIGN(16) union uint512_u buf;
-
-    memset(&buf, 0x00, sizeof buf);
-    memcpy(&buf, &(CTX->buffer), CTX->bufsize);
-    memcpy(&(CTX->buffer), &buf, sizeof(uint512_u));
-
-    memset(&buf, 0x00, sizeof buf);
-#ifndef __GOST3411_BIG_ENDIAN__
-    buf.QWORD[0] = CTX->bufsize << 3;
-#else
-    buf.QWORD[0] = BSWAP64(CTX->bufsize << 3);
-#endif
-
     pad(CTX);
-
     g(&(CTX->h), &(CTX->N), &(CTX->buffer));
-
-    add512(&(CTX->N), &buf);
     add512(&(CTX->Sigma), &CTX->buffer);
 
-    g(&(CTX->h), &buffer0, &(CTX->N));
+    memset(&(CTX->buffer.B[0]), 0, sizeof(uint512_u));
+#ifndef __GOST3411_BIG_ENDIAN__
+    CTX->buffer.QWORD[0] = CTX->bufsize << 3;
+#else
+    CTX->buffer.QWORD[0] = BSWAP64(CTX->bufsize << 3);
+#endif
+    add512(&(CTX->N), &(CTX->buffer));
 
+    g(&(CTX->h), &buffer0, &(CTX->N));
     g(&(CTX->h), &buffer0, &(CTX->Sigma));
 }
 

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -150,13 +150,10 @@ static void g(union uint512_u *h, const union uint512_u *N,
 
 static INLINE void stage2(gost2012_hash_ctx * CTX, const unsigned char *data)
 {
-    union uint512_u m;
-
-    memcpy(&m, data, sizeof(m));
-    g(&(CTX->h), &(CTX->N), (const unsigned char *)&m);
+    g(&(CTX->h), &(CTX->N), data);
 
     add512(&(CTX->N), &buffer512);
-    add512(&(CTX->Sigma), &m);
+    add512(&(CTX->Sigma), (const union uint512_u *)data);
 }
 
 static INLINE void stage3(gost2012_hash_ctx * CTX)
@@ -196,7 +193,8 @@ void gost2012_hash_block(gost2012_hash_ctx * CTX,
     size_t chunksize;
 
     while (len > 63 && CTX->bufsize == 0) {
-        stage2(CTX, data);
+        memcpy(&CTX->buffer[0], data, 64);
+        stage2(CTX, &CTX->buffer[0]);
 
         data += 64;
         len -= 64;

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -45,9 +45,6 @@ static INLINE void pad(gost2012_hash_ctx * CTX)
 {
     unsigned char buf[64];
 
-    if (CTX->bufsize > 63)
-        return;
-
     memset(&buf, 0x00, sizeof buf);
     memcpy(&buf, CTX->buffer, CTX->bufsize);
 

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -118,7 +118,7 @@ static void g(union uint512_u *h, const union uint512_u * RESTRICT N,
     LOAD(N, xmm0, xmm2, xmm4, xmm6);
     XLPS128M(h, xmm0, xmm2, xmm4, xmm6);
 
-    LOAD(m, xmm1, xmm3, xmm5, xmm7);
+    ULOAD(m, xmm1, xmm3, xmm5, xmm7);
     XLPS128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
     for (i = 0; i < 11; i++)
@@ -128,12 +128,10 @@ static void g(union uint512_u *h, const union uint512_u * RESTRICT N,
     X128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
     X128M(h, xmm0, xmm2, xmm4, xmm6);
-    X128M(m, xmm0, xmm2, xmm4, xmm6);
+    ULOAD(m, xmm1, xmm3, xmm5, xmm7);
+    X128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
-    UNLOAD(h, xmm0, xmm2, xmm4, xmm6);
-
-    /* Restore the Floating-point status on the CPU */
-    _mm_empty();
+    STORE(h, xmm0, xmm2, xmm4, xmm6);
 #else
     union uint512_u Ki, data;
     unsigned int i;

--- a/gosthash2012.h
+++ b/gosthash2012.h
@@ -10,12 +10,8 @@
 
 #include <string.h>
 
-#ifdef OPENSSL_IA32_SSE2
-# ifdef __MMX__
-#  ifdef __SSE2__
-#   define __GOST3411_HAS_SSE2__
-#  endif
-# endif
+#ifdef __SSE2__
+# define __GOST3411_HAS_SSE2__
 #endif
 
 #ifdef __GOST3411_HAS_SSE2__
@@ -27,6 +23,7 @@
 #ifndef L_ENDIAN
 # define __GOST3411_BIG_ENDIAN__
 #endif
+
 #if defined __GOST3411_HAS_SSE2__
 # include "gosthash2012_sse2.h"
 #else

--- a/gosthash2012.h
+++ b/gosthash2012.h
@@ -48,6 +48,7 @@
 ALIGN(16)
 typedef union uint512_u {
     unsigned long long QWORD[8];
+    unsigned char B[64];
 } uint512_u;
 
 #include "gosthash2012_const.h"
@@ -55,7 +56,7 @@ typedef union uint512_u {
 
 /* GOST R 34.11-2012 hash context */
 typedef struct gost2012_hash_ctx {
-    unsigned char buffer[64];
+    union uint512_u buffer;
     union uint512_u h;
     union uint512_u N;
     union uint512_u Sigma;

--- a/gosthash2012.h
+++ b/gosthash2012.h
@@ -50,7 +50,6 @@ typedef union uint512_u {
 /* GOST R 34.11-2012 hash context */
 typedef struct gost2012_hash_ctx {
     unsigned char buffer[64];
-    union uint512_u hash;
     union uint512_u h;
     union uint512_u N;
     union uint512_u Sigma;

--- a/gosthash2012.h
+++ b/gosthash2012.h
@@ -33,6 +33,12 @@
 # include "gosthash2012_ref.h"
 #endif
 
+# if defined(__GNUC__) || defined(__clang__)
+#  define RESTRICT __restrict__
+# else
+#  define RESTRICT
+# endif
+
 #ifdef _MSC_VER
 # define ALIGN(x) __declspec(align(x))
 #else

--- a/gosthash2012.h
+++ b/gosthash2012.h
@@ -12,6 +12,17 @@
 
 #ifdef __SSE2__
 # define __GOST3411_HAS_SSE2__
+# if !defined(__x86_64__)
+/*
+ * x86-64 bit Linux and Windows ABIs provide malloc function that returns
+ * 16-byte alignment memory buffers required by SSE load/store instructions.
+ * Other platforms require special trick for proper gost2012_hash_ctx structure
+ * allocation. It will be easier to switch to unaligned loadu/storeu memory
+ * access instructions in this case.
+ */
+#  define UNALIGNED_SIMD_ACCESS
+#  pragma message "Use unaligned SIMD memory access"
+# endif
 #endif
 
 #ifdef __GOST3411_HAS_SSE2__

--- a/gosthash2012_ref.h
+++ b/gosthash2012_ref.h
@@ -12,6 +12,8 @@
 # error "GOST R 34.11-2012: portable implementation disabled in config.h"
 #endif
 
+# pragma message "Use regular implementation"
+
 #define X(x, y, z) { \
     z->QWORD[0] = x->QWORD[0] ^ y->QWORD[0]; \
     z->QWORD[1] = x->QWORD[1] ^ y->QWORD[1]; \

--- a/gosthash2012_sse2.h
+++ b/gosthash2012_sse2.h
@@ -12,6 +12,8 @@
 # error "GOST R 34.11-2012: SSE2 not enabled"
 #endif
 
+# pragma message "Use SIMD implementation"
+
 #include <mmintrin.h>
 #include <emmintrin.h>
 


### PR DESCRIPTION
Пример PR для @ddulesov из #198. Изменения разбиты на мелкие смысловые части. SIMD и `_addcarry_u64` изменений я не добавлял. Список коммитов:

* gosthash2012: Optimize out temporary `buf' from `stage3'
* gosthash2012: Optimize `gost2012_hash_block' loop
* gosthash2012: Change some byte (pointers) to union uint512_u
* gosthash2012: Remove temporary variable from `stage2'
* gosthash2012: Make `add512' to work in-place
* gosthash2012: Simplify `pad'
* gosthash2012: Remove redundant `memset' form `init_gost2012_hash_ctx'
* gosthash2012: Remove redundant `hash' field from `struct gost2012_hash_ctx'

Там есть немного моих изменений:

* gosthash2012: Remove unreachable code from `pad'
* gosthash2012: Simpler version of add512

Кроме этих двух коммитов везде автором указан dmitry dulesov. Раз уж я работал, то я везде в commit message добавил себя в не стандартный тэг `Committed-by`, что значит, что я подготовил коммит. Можете взять за основу эти коммиты и/или поменять как хотите. Да, это заняло пару часов.

