### PR TITLE
CMakeLists.txt: Workaround openssl deprecation of HMAC and CMAC primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ if (ASAN)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -g3 -fno-omit-frame-pointer")
 endif()
 
+# DEPRECATEDIN_3_0 CMAC
+set_source_files_properties(gost_omac.c PROPERTIES COMPILE_FLAGS -Wno-error=deprecated-declarations)
+# DEPRECATEDIN_3_0 HMAC
+set_source_files_properties(gost_keyexpimp.c PROPERTIES COMPILE_FLAGS -Wno-error=deprecated-declarations)
+
 set(CMAKE_C_STANDARD 90)
 CHECK_FUNCTION_EXISTS(clock_gettime HAVE_CLOCK_GETTIME_C)
 CHECK_LIBRARY_EXISTS(rt clock_gettime "" HAVE_CLOCK_GETTIME_RT)


### PR DESCRIPTION
Following commits mark CMAC and HMAC primitives deprecated:

  commit a6d572e60120e0ffb42aece17a085f0fed1b8f6f
  Author: Pauli <paul.dale@oracle.com>
  Date:   Tue Jan 14 10:59:11 2020 +1000

      Deprecate the low level CMAC functions

  commit dbde4726889a19af0a718fe9c5542f39c81acbd3
  Author: Pauli <paul.dale@oracle.com>
  Date:   Tue Jan 14 12:11:50 2020 +1000

      Deprecate the low level HMAC functions

Add `-Wno-error=deprecated-declarations' to appropriate targets.

References:
  https://github.com/openssl/openssl/commit/a6d572e601
  https://github.com/openssl/openssl/commit/dbde472688