### PR TITLE
.travis.yml improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,9 @@ before_script:
   - git clone --depth 1 -b ${OPENSSL_BRANCH} https://github.com/openssl/openssl.git
   - cd openssl
   - git describe --always --long
-  - ./config shared -d --prefix=${PREFIX} --openssldir=${PREFIX} -Wl,-rpath=${PREFIX}/lib && travis_wait make -s -j$(nproc) all && make -s install_sw
+  - ./config shared -d --prefix=${PREFIX} --openssldir=${PREFIX} -Wl,-rpath=${PREFIX}/lib
+  - travis_wait make -s -j$(nproc) build_sw
+  - make -s install_sw
   - cd ..
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
   - sudo cpanm --notest Test2::V0 > build.log 2>&1 || (cat build.log && exit 1)
   - git clone --depth 1 -b ${OPENSSL_BRANCH} https://github.com/openssl/openssl.git
   - cd openssl
+  - git describe --always --long
   - ./config shared -d --prefix=${PREFIX} --openssldir=${PREFIX} -Wl,-rpath=${PREFIX}/lib && travis_wait make -s -j$(nproc) all && make -s install_sw
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ matrix:
       os: linux
       arch: arm64
       compiler: gcc
+    - name: linux/gcc/s390x/openssl-master
+      os: linux
+      arch: s390x
+      compiler: gcc
     - name: osx/clang/x86_64/openssl-master
       os: osx
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
     - name: linux/clang/x86_64/openssl-master
       os: linux
       compiler: clang
+    - name: linux/gcc/i386/openssl-master
+      os: linux
+      compiler: gcc
+      env: CFLAGS=-m32 LDFLAGS=-m32 SETARCH="setarch i386" APT_INSTALL=gcc-multilib
     - name: linux/gcc/x86_64/openssl-1.1.1
       os: linux
       compiler: gcc
@@ -56,11 +60,12 @@ matrix:
 before_script:
   - curl -L https://cpanmin.us | sudo perl - --sudo App::cpanminus
   - sudo cpanm --notest Test2::V0 > build.log 2>&1 || (cat build.log && exit 1)
+  - if [ "$APT_INSTALL" ]; then sudo apt-get install -y $APT_INSTALL; fi
   - git clone --depth 1 -b ${OPENSSL_BRANCH} https://github.com/openssl/openssl.git
   - cd openssl
   - git describe --always --long
-  - ./config shared -d --prefix=${PREFIX} --openssldir=${PREFIX} -Wl,-rpath=${PREFIX}/lib
-  - travis_wait make -s -j$(nproc) build_sw
+  - $SETARCH ./config shared -d --prefix=${PREFIX} --openssldir=${PREFIX} -Wl,-rpath=${PREFIX}/lib
+  - travis_wait $SETARCH make -s -j$(nproc) build_sw
   - make -s install_sw
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - name: linux/gcc/x86_64/openssl-master
       os: linux
       compiler: gcc
+    - name: linux/clang/x86_64/openssl-master
+      os: linux
+      compiler: clang
     - name: linux/gcc/x86_64/openssl-1.1.1
       os: linux
       compiler: gcc


### PR DESCRIPTION
* 794ec44 travis-ci: Always describe openssl branch
- Отображение commit id, так как `master` может менять от времени. Чтоб было ясно какой именно master был на момент запуска тестов.
* ae8f2c6 travis-ci: Add clang build for linux/x86_64/openssl-master
- clang без OSX. Так как OSX может вносить свои ошибки, а интерсно проверить clang без них.
* d7e7c64 travis-ci: Add (big-endian) s390x build
- Big-endian arch.
* 0e7e5ea travis-ci: Speed-up openssl build
- Не собирать man pages.
* 984f50b travis-ci: Add 32-bit build (i386)
- 32-bit arch.
