### PR TITLE
Streebog: _addcarry_u64 test and XLPS optimizations for ref code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(gost-engine LANGUAGES C)
 include(GNUInstallDirs)
 include(CheckLibraryExists)
 include(CheckFunctionExists)
+include(CheckCSourceRuns)
 
 enable_testing()
 
@@ -45,6 +46,23 @@ if(IS_BIG_ENDIAN)
 else()
  message(STATUS "LITTLE_ENDIAN")
  add_definitions(-DL_ENDIAN)
+endif()
+
+check_c_source_runs("
+  #ifdef _MSC_VER
+  # include <intrin.h>
+  #else
+  # include <x86intrin.h>
+  #endif
+  int main(void) {
+  unsigned long long x = -1, y = 1, r;
+    unsigned char cf;
+    cf = _addcarry_u64(1, (unsigned long)x, y, &r);
+    return !(cf == 1 && r == 1);
+  }
+  " ADDCARRY_U64)
+if (ADDCARRY_U64)
+  add_definitions(-DHAVE_ADDCARRY_U64)
 endif()
 
 set(BIN_DIRECTORY bin)

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -10,8 +10,11 @@
 
 #include "gosthash2012.h"
 #ifdef __x86_64__
-# include <immintrin.h>
-# include <x86intrin.h>
+# ifdef _MSC_VER
+#  include <intrin.h>
+# else
+#  include <x86intrin.h>
+# endif
 #endif
 
 #if defined(_WIN32) || defined(_WINDOWS)
@@ -64,7 +67,7 @@ static INLINE void add512(union uint512_u * RESTRICT x,
     unsigned int CF = 0;
     unsigned int i;
 
-# ifdef __x86_64__
+# ifdef HAVE_ADDCARRY_U64
     for (i = 0; i < 8; i++)
 	CF = _addcarry_u64(CF, x->QWORD[i] , y->QWORD[i], &(x->QWORD[i]));
 # else

--- a/gosthash2012_ref.h
+++ b/gosthash2012_ref.h
@@ -25,11 +25,10 @@
     z->QWORD[7] = x->QWORD[7] ^ y->QWORD[7]; \
 }
 
-#ifndef __GOST3411_BIG_ENDIAN__
 # define __XLPS_FOR for (_i = 0; _i <= 7; _i++)
+#ifndef __GOST3411_BIG_ENDIAN__
 # define _datai _i
 #else
-# define __XLPS_FOR for (_i = 7; _i >= 0; _i--)
 # define _datai 7 - _i
 #endif
 
@@ -48,14 +47,22 @@
     \
     \
     __XLPS_FOR {\
-        data->QWORD[_datai]  = Ax[0][(r0 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[1][(r1 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[2][(r2 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[3][(r3 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[4][(r4 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[5][(r5 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[6][(r6 >> (_i << 3)) & 0xFF]; \
-        data->QWORD[_datai] ^= Ax[7][(r7 >> (_i << 3)) & 0xFF]; \
+        data->QWORD[_datai]  = Ax[0][r0 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[1][r1 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[2][r2 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[3][r3 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[4][r4 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[5][r5 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[6][r6 & 0xFF]; \
+        data->QWORD[_datai] ^= Ax[7][r7 & 0xFF]; \
+        r0 >>= 8; \
+        r1 >>= 8; \
+        r2 >>= 8; \
+        r3 >>= 8; \
+        r4 >>= 8; \
+        r5 >>= 8; \
+        r6 >>= 8; \
+        r7 >>= 8; \
     }\
 }
 


### PR DESCRIPTION
* Добавил в cmake тест наличия рабочего `_addcarry_u64`
* Небольшая оптимизация XLPS для `-ref` имплементации.

То о чём говорилось в #206.
