### PR TITLE
gosthash2012: Issue EMMS on 32-bit SIMD implementation

### DIFF
--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -135,6 +135,11 @@ static void g(union uint512_u *h, const union uint512_u * RESTRICT N,
     X128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
     STORE(h, xmm0, xmm2, xmm4, xmm6);
+# ifndef __x86_64__
+    /* Restore the Floating-point status on the CPU */
+    /* This is only required on MMX, but EXTRACT32 is using MMX */
+    _mm_empty();
+# endif
 #else
     union uint512_u Ki, data;
     unsigned int i;


### PR DESCRIPTION
`_mm_empty' is not needed on x86_64, because we only using SSE2.

But, I didn't notice that EXTRACT32 (32-bit version of EXTRACT) is
using MMX registers and intrinsics, so complete removing of
`_mm_empty' (EMMS) was mistake.

Make it presence conditional only for IA-32.

Fixes: 211489f ("gosthash2012: Improve SIMD implementation")

Предыдущее обсуждение: https://github.com/gost-engine/engine/pull/206#issuecomment-582853071
Я не смог удалить MMX код без замедления, поэтому пока просто возвращаю `_mm_empty`.

Заодно добавил комментарий, чтоб в следующий раз не забыли про это.