### PR TITLE
ec: Use BN_{CTX_,}secure_new memory API for priv keys

### DIFF
--- a/gost89.c
+++ b/gost89.c
@@ -452,7 +452,7 @@ void gost_enc_with_key(gost_ctx * c, byte * key, byte * inblock,
 void gost_key(gost_ctx * c, const byte * k)
 {
     int i, j;
-    RAND_bytes((unsigned char *)c->mask, sizeof(c->mask));
+    RAND_priv_bytes((unsigned char *)c->mask, sizeof(c->mask));
     for (i = 0, j = 0; i < 8; ++i, j += 4) {
         c->key[i] =
             (k[j] | (k[j + 1] << 8) | (k[j + 2] << 16) | ((word32) k[j + 3] <<
@@ -464,7 +464,7 @@ void gost_key(gost_ctx * c, const byte * k)
 void magma_key(gost_ctx * c, const byte * k)
 {
     int i, j;
-    RAND_bytes((unsigned char *)c->mask, sizeof(c->mask));
+    RAND_priv_bytes((unsigned char *)c->mask, sizeof(c->mask));
     for (i = 0, j = 0; i < 8; ++i, j += 4) {
         c->key[i] =
             (k[j + 3] | (k[j + 2] << 8) | (k[j + 1] << 16) | ((word32) k[j] <<

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -876,7 +876,7 @@ int gost_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 #endif
     case EVP_CTRL_RAND_KEY:
         {
-            if (RAND_bytes
+            if (RAND_priv_bytes
                 ((unsigned char *)ptr, EVP_CIPHER_CTX_key_length(ctx)) <= 0) {
                 GOSTerr(GOST_F_GOST_CIPHER_CTL, GOST_R_RNG_ERROR);
                 return -1;

--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -338,9 +338,11 @@ static int pkey_GOST_ECcp_encrypt(EVP_PKEY_CTX *pctx, unsigned char *out,
     }
     if ((*out_len = i2d_GOST_KEY_TRANSPORT(gkt, out ? &out : NULL)) > 0)
         ret = 1;
+    OPENSSL_cleanse(shared_key, sizeof(shared_key));
     GOST_KEY_TRANSPORT_free(gkt);
     return ret;
  err:
+    OPENSSL_cleanse(shared_key, sizeof(shared_key));
     if (key_is_ephemeral)
         EVP_PKEY_free(sec_key);
     GOST_KEY_TRANSPORT_free(gkt);
@@ -444,6 +446,7 @@ static int pkey_gost2018_encrypt(EVP_PKEY_CTX *pctx, unsigned char *out,
     if ((*out_len = i2d_PSKeyTransport_gost(pst, out ? &out : NULL)) > 0)
         ret = 1;
  err:
+    OPENSSL_cleanse(expkeys, sizeof(expkeys));
     if (key_is_ephemeral)
       EVP_PKEY_free(sec_key);
 
@@ -550,6 +553,7 @@ static int pkey_GOST_ECcp_decrypt(EVP_PKEY_CTX *pctx, unsigned char *key,
 
     ret = 1;
  err:
+    OPENSSL_cleanse(sharedKey, sizeof(sharedKey));
     EVP_PKEY_free(eph_key);
     GOST_KEY_TRANSPORT_free(gkt);
     return ret;
@@ -630,6 +634,7 @@ static int pkey_gost2018_decrypt(EVP_PKEY_CTX *pctx, unsigned char *key,
 
     ret = 1;
  err:
+    OPENSSL_cleanse(expkeys, sizeof(expkeys));
     EVP_PKEY_free(eph_key);
     PSKeyTransport_gost_free(pst);
     return ret;

--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -27,7 +27,7 @@ int VKO_compute_key(unsigned char *shared_key,
     BIGNUM *UKM = NULL, *p = NULL, *order = NULL, *X = NULL, *Y = NULL, *cofactor = NULL;
     const BIGNUM *key = EC_KEY_get0_private_key(priv_key);
     EC_POINT *pnt = EC_POINT_new(EC_KEY_get0_group(priv_key));
-    BN_CTX *ctx = BN_CTX_new();
+    BN_CTX *ctx = BN_CTX_secure_new();
     EVP_MD_CTX *mdctx = NULL;
     const EVP_MD *md = NULL;
     int buf_len, half_len;
@@ -45,7 +45,7 @@ int VKO_compute_key(unsigned char *shared_key,
         goto err;
     }
 
-    UKM = hashsum2bn(ukm, ukm_size);
+    UKM = BN_lebin2bn(ukm, ukm_size, NULL);
     p = BN_CTX_get(ctx);
     order = BN_CTX_get(ctx);
 		cofactor = BN_CTX_get(ctx);

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -743,7 +743,7 @@ int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg,
 {
     switch (type) {
     case EVP_CTRL_RAND_KEY:{
-            if (RAND_bytes
+            if (RAND_priv_bytes
                 ((unsigned char *)ptr, EVP_CIPHER_CTX_key_length(ctx)) <= 0) {
                 GOSTerr(GOST_F_GOST_GRASSHOPPER_CIPHER_CTL, GOST_R_RNG_ERROR);
                 return -1;

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -292,9 +292,6 @@ int gost_kimp15(const unsigned char *expkey, const size_t expkeylen,
                 const unsigned char *iv, const size_t ivlen,
                 unsigned char *shared_key);
 /*============== miscellaneous functions============================= */
-/* from gost_sign.c */
-/* Convert GOST R 34.11 hash sum to bignum according to standard */
-BIGNUM *hashsum2bn(const unsigned char *dgst, int len);
 /*
  * Store bignum in byte array of given length, prepending by zeros if
  * nesseccary


### PR DESCRIPTION
OpenSSL suggests to use (and internally itself uses)
`BN_{CTX_,}secure_new' primitives to work with private keys.

These are using `OPENSSL_secure_malloc' et al. calls, which use
special 'secure heap' memory.

https://www.openssl.org/docs/manmaster/man3/OPENSSL_secure_malloc.html

Надеюсь, нигде не пропустил.
