### PR TITLE
cppcheck: Variable is reassigned a value before the old one has been …

### DIFF
--- a/gost89.h
+++ b/gost89.h
@@ -78,7 +78,7 @@ int gost_mac(gost_ctx * ctx, int mac_len, const unsigned char *data,
  * Compute MAC of given length in bits from data, using non-zero 8-byte IV
  * (non-standard, for use in CryptoPro key transport only
  */
-int gost_mac_iv(gost_ctx * c, int mac_len, const unsigned char *iv,
+int gost_mac_iv(gost_ctx * ctx, int mac_len, const unsigned char *iv,
                 const unsigned char *data, unsigned int data_len,
                 unsigned char *mac);
 /* Perform one step of MAC calculation like gostcrypt */

--- a/gost_ameth.c
+++ b/gost_ameth.c
@@ -392,8 +392,7 @@ static int priv_decode_gost(EVP_PKEY *pk,
         pk_num = ASN1_INTEGER_to_BN(priv_key, BN_secure_new());
         ASN1_INTEGER_free(priv_key);
     } else if ((V_ASN1_SEQUENCE | V_ASN1_CONSTRUCTED) == *p) {
-        MASKED_GOST_KEY *mgk = NULL;
-        mgk = d2i_MASKED_GOST_KEY(NULL, &p, priv_len);
+        MASKED_GOST_KEY *mgk = d2i_MASKED_GOST_KEY(NULL, &p, priv_len);
 
         if (!mgk) {
             GOSTerr(GOST_F_PRIV_DECODE_GOST, EVP_R_DECODE_ERROR);
@@ -460,10 +459,9 @@ static int priv_encode_gost(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pk)
     }
 
     if (pk_format != NULL && strcmp(pk_format, PK_WRAP_PARAM) == 0) {
-        ASN1_STRING *octet = NULL;
+        ASN1_STRING *octet = ASN1_STRING_new();
         int priv_len = 0;
         unsigned char *priv_buf = NULL;
-        octet = ASN1_STRING_new();        
         if (!octet || !ASN1_OCTET_STRING_set(octet, buf, key_len)) {
             ASN1_STRING_free(octet);
             ASN1_STRING_free(params);
@@ -723,13 +721,13 @@ static int pub_decode_gost_ec(EVP_PKEY *pk, X509_PUBKEY *pub)
 
 static int pub_encode_gost_ec(X509_PUBKEY *pub, const EVP_PKEY *pk)
 {
-    ASN1_OBJECT *algobj = NULL;
+    ASN1_OBJECT *algobj;
     ASN1_OCTET_STRING *octet = NULL;
-    void *pval = NULL;
+    void *pval;
     unsigned char *buf = NULL, *databuf = NULL;
     int data_len, ret = -1;
     const EC_POINT *pub_key;
-    BIGNUM *X = NULL, *Y = NULL, *order = NULL;
+    BIGNUM *X = NULL, *Y = NULL, *order;
     const EC_KEY *ec = EVP_PKEY_get0((EVP_PKEY *)pk);
     int ptype = V_ASN1_SEQUENCE;
     ASN1_STRING *params;

--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -152,7 +152,6 @@ static int gost_keg(const unsigned char *ukm_source, int pkey_nid,
 
             OPENSSL_cleanse(tmpkey, 32);
             return (keylen) ? keylen : 0;
-            break;
         }
     default:
         return 0;

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -692,9 +692,7 @@ int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 {
     int len = 0;
     unsigned char *buf = NULL;
-    ASN1_OCTET_STRING *os = NULL;
-
-    os = ASN1_OCTET_STRING_new();
+    ASN1_OCTET_STRING *os = ASN1_OCTET_STRING_new();
 
     if (!os || !ASN1_OCTET_STRING_set(os, buf, len)) {
         ASN1_OCTET_STRING_free(os);

--- a/gost_keyexpimp.c
+++ b/gost_keyexpimp.c
@@ -176,7 +176,7 @@ int gost_kdftree2012_256(unsigned char *keyout, size_t keyout_len,
     int iters, i = 0;
     unsigned char zero = 0;
     unsigned char *ptr = keyout;
-    HMAC_CTX *ctx = NULL;
+    HMAC_CTX *ctx;
     unsigned char *len_ptr = NULL;
     uint32_t len_repr = htonl(keyout_len * 8);
     size_t len_repr_len = 4;

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -241,7 +241,7 @@ const EVP_CIPHER *cipher_magma_cbc();
 const EVP_CIPHER *cipher_magma_ctr();
 void cipher_gost_destroy();
 
-void inc_counter(unsigned char *buffer, size_t buf_len);
+void inc_counter(unsigned char *counter, size_t counter_bytes);
 
 # define EVP_MD_CTRL_KEY_LEN (EVP_MD_CTRL_ALG_CTRL+3)
 # define EVP_MD_CTRL_SET_KEY (EVP_MD_CTRL_ALG_CTRL+4)
@@ -278,8 +278,8 @@ int gost_kdftree2012_256(unsigned char *keyout, size_t keyout_len,
                          const unsigned char *seed, size_t seed_len,
                          const size_t representation);
 
-int gost_tlstree(int cipher_nid, const unsigned char* inkey,
-                unsigned char *outkey, const unsigned char *tlsseq);
+int gost_tlstree(int cipher_nid, const unsigned char *in, unsigned char *out,
+                 const unsigned char *tlsseq);
 /* KExp/KImp */
 int gost_kexp15(const unsigned char *shared_key, const int shared_len,
                 int cipher_nid, const unsigned char *cipher_key,

--- a/test_sign.c
+++ b/test_sign.c
@@ -157,7 +157,7 @@ static int test_sign(struct test_sign *t)
     const EC_GROUP *group = EC_KEY_get0_group(ec);
     int curve_name = EC_GROUP_get_curve_name(group);
     err = curve_name == t->nid;
-    printf("\tcurve_name (%d):\t", t->nid);
+    printf("\tcurve_name (%u):\t", t->nid);
     print_test_tf(err, curve_name, "match", "mismatch");
     ret |= !err;
 


### PR DESCRIPTION
…used.

Plus some minor chnages
- function defenition doen't match function declaration
- Consecutive break statement is unnecessary.
- Type missmatch in format string