### PR TITLE
Misc test improvements + Fix Magma CBC

### DIFF
--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -785,10 +785,11 @@ int magma_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
                 d[7 - i] = in_ptr[i];
             }
             gostdecrypt(&(c->cctx), d, b);
+            memcpy(d, in_ptr, 8);
             for (i = 0; i < 8; i++) {
                 out_ptr[i] = iv[i] ^ b[7 - i];
             }
-            memcpy(iv, in_ptr, 8);
+            memcpy(iv, d, 8);
             out_ptr += 8;
             in_ptr += 8;
             inl -= 8;

--- a/test_ciphers.c
+++ b/test_ciphers.c
@@ -24,6 +24,7 @@
 #define cGREEN	"\033[1;32m"
 #define cDGREEN	"\033[0;32m"
 #define cBLUE	"\033[1;34m"
+#define cMAGENT "\033[1;35m"
 #define cDBLUE	"\033[0;34m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
@@ -488,6 +489,19 @@ int main(int argc, char **argv)
 	    ret |= test_stream(type, name,
 		t->plaintext, t->key, t->expected, t->size,
 		t->iv, t->iv_size, t->acpkm);
+    }
+
+    ENGINE_CIPHERS_PTR fn_c;
+    T(fn_c = ENGINE_get_ciphers(eng));
+    const int *nids;
+    int n, k;
+    n = fn_c(eng, NULL, &nids, 0);
+    for (k = 0; k < n; ++k) {
+	for (t = testcases; t->nid; t++)
+	    if (t->nid == nids[k])
+		break;
+	if (!t->nid)
+	    printf(cMAGENT "Cipher %s is untested!\n" cNORM, OBJ_nid2sn(nids[k]));
     }
 
     ENGINE_finish(eng);

--- a/test_ciphers.c
+++ b/test_ciphers.c
@@ -276,7 +276,6 @@ static struct testcase {
 	.iv = iv_ctr,
 	.iv_size = sizeof(iv_ctr) / 2,
     },
-#if 0
     {
 	.nid = NID_magma_cbc,
 	.block = 8,
@@ -287,7 +286,6 @@ static struct testcase {
 	.iv = iv_cbc,
 	.iv_size = sizeof(iv_cbc),
     },
-#endif
     { 0 }
 };
 

--- a/test_digest.c
+++ b/test_digest.c
@@ -47,6 +47,7 @@
 #define cDGREEN	"\033[0;32m"
 #define cBLUE	"\033[1;34m"
 #define cDBLUE	"\033[0;34m"
+#define cMAGENT "\033[1;35m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
 		 printf(cRED "  Test FAILED\n" cNORM); \
@@ -724,6 +725,19 @@ int main(int argc, char **argv)
 	    ret |= do_test(tv);
 	else
 	    ret |= do_synthetic_test(tv);
+    }
+
+    ENGINE_DIGESTS_PTR fn_c;
+    T(fn_c = ENGINE_get_digests(eng));
+    const int *nids;
+    int n, k;
+    n = fn_c(eng, NULL, &nids, 0);
+    for (k = 0; k < n; ++k) {
+	for (tv = testvecs; tv->nid; tv++)
+	    if (tv->nid == nids[k])
+		break;
+	if (!tv->nid)
+	    printf(cMAGENT "Digest %s is untested!\n" cNORM, OBJ_nid2sn(nids[k]));
     }
 
     ENGINE_finish(eng);

--- a/test_digest.c
+++ b/test_digest.c
@@ -163,6 +163,14 @@ static const char etalon_carry[] = {
     0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x16,
 };
 
+/* This is another carry test. */
+static const char ff[] = {
+    0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+    0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+    0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+    0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff
+};
+
 struct hash_testvec {
     int nid;		   /* OpenSSL algorithm numeric id. */
     const char *name;	   /* Test name and source. */
@@ -398,7 +406,7 @@ static const struct hash_testvec testvecs[] = {
 	    "\x2f\x4f\x65\x1f\xe8\x8f\xea\x46\xec\x6f\x22\x23\x72\x8d\x8d\xff"
 	    "\x39\x68\x89\x35\x58\xef\x00\xa3\x10\xc2\x3e\x7d\x19\x23\xba\x0c"
     },
-    { /* carry */
+    { /* Carry */
 	.nid = NID_id_GostR3411_2012_512,
 	.name = "(carry)",
 	.plaintext = etalon_carry,
@@ -418,6 +426,35 @@ static const struct hash_testvec testvecs[] = {
 	    "\x81\xbb\x63\x2f\xa3\x1f\xcc\x38\xb4\xc3\x79\xa6\x62\xdb\xc5\x8b"
 	    "\x9b\xed\x83\xf5\x0d\x3a\x1b\x2c\xe7\x27\x1a\xb0\x2d\x25\xba\xbb"
     },
+    { /* ff (Better carry test). */
+	.nid = NID_id_GostR3411_2012_512,
+	.name = "64 bytes of FF",
+	.plaintext = ff,
+	.psize = sizeof(ff),
+	.digest =
+	    "\x41\x62\x9d\xe6\x77\xd7\xe8\x09\x0c\x3c\xd7\x0a\xff\xe3\x30\x0d"
+	    "\x1e\x1c\xfb\xa2\xdb\x97\x94\x5e\xc3\x7f\xeb\x4e\x13\x75\xbc\x02"
+	    "\xa5\x3f\x00\x37\x0b\x7d\x71\x5b\x07\xf3\x7f\x93\xca\xc8\x44\xef"
+	    "\xad\xbf\xd1\xb8\x5f\x9d\xda\xe3\xde\x96\x56\xc0\xe9\x5a\xff\xc7"
+    },
+    {
+	.nid = NID_id_GostR3411_2012_256,
+	.name = "64 bytes of FF",
+	.plaintext = ff,
+	.psize = sizeof(ff),
+	.digest =
+	    "\x96\x4a\x5a\xb6\x02\x86\xf1\x06\x28\x87\x43\xe2\xfe\x1a\x42\x2d"
+	    "\x16\x08\x98\xca\x1b\xd5\x35\xe8\x31\xaa\x50\x0c\xfe\x34\xd7\xe8"
+    },
+    {
+	.nid = NID_id_GostR3411_94,
+	.name = "64 bytes of FF",
+	.plaintext = ff,
+	.psize = sizeof(ff),
+	.digest =
+	    "\x58\x50\x4d\x26\xb3\x67\x7e\x75\x6b\xa3\xf4\xa9\xfd\x2f\x14\xb3"
+	    "\xba\x54\x57\x06\x6a\x4a\xa1\xd7\x00\x65\x9b\x90\xdc\xdd\xd3\xc6"
+    },
     /* Synthetic tests. */
     {
 	.nid = NID_id_GostR3411_2012_256,
@@ -427,7 +464,8 @@ static const struct hash_testvec testvecs[] = {
 	.digest =
 	    "\xa2\xf3\x6d\x9c\x42\xa1\x1e\xad\xe3\xc1\xfe\x99\xf9\x99\xc3\x84"
 	    "\xe7\x98\xae\x24\x50\x75\x73\xd7\xfc\x99\x81\xa0\x45\x85\x41\xf6"
-    }, {
+    },
+    {
 	.nid = NID_id_GostR3411_2012_512,
 	.name = "streebog512 synthetic test",
 	.mdsize = 64,


### PR DESCRIPTION
```
test_ciphers: Enable Magma CBC test
gost_crypt: Fix Magma CBC in-place decryption
test_digest: Add another carry test vector, also test GOST94
test_digest: Reduce arguments to tests, make concise logging
test_digest: Test CMAC using EVP_MAC (provider) API
test_digest: Test old and new APIs
test: List untested digests and ciphers
```
