### PR TITLE
Rework ciphers registrtion

### DIFF
--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -213,41 +213,27 @@ GOST_cipher magma_ctr_acpkm_cipher = {
     .ctrl = magma_cipher_ctl,
 };
 
-static EVP_CIPHER *_hidden_magma_ctr_acpkm_omac = NULL;
-const EVP_CIPHER *cipher_magma_ctr_acpkm_omac(void)
-{
-    if (_hidden_magma_ctr_acpkm_omac == NULL
-        && ((_hidden_magma_ctr_acpkm_omac =
-             EVP_CIPHER_meth_new(NID_magma_ctr_acpkm_omac, 1 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_magma_ctr_acpkm_omac, 4)
-            || !EVP_CIPHER_meth_set_flags(_hidden_magma_ctr_acpkm_omac,
-                                          EVP_CIPH_CTR_MODE |
-                                          EVP_CIPH_NO_PADDING |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT |
-																					EVP_CIPH_CUSTOM_COPY |
-																					EVP_CIPH_FLAG_CUSTOM_CIPHER |
-																					EVP_CIPH_FLAG_CIPHER_WITH_MAC)
-            || !EVP_CIPHER_meth_set_init(_hidden_magma_ctr_acpkm_omac, magma_cipher_init_ctr_acpkm_omac)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_magma_ctr_acpkm_omac,
-                                              magma_cipher_do_ctr_acpkm_omac)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_magma_ctr_acpkm_omac,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_magma_ctr_acpkm_omac,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_magma_ctr_acpkm_omac,
-                                                    magma_set_asn1_parameters)
-            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_magma_ctr_acpkm_omac,
-                                                    magma_get_asn1_parameters)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_magma_ctr_acpkm_omac, magma_cipher_ctl_acpkm_omac))) {
-        EVP_CIPHER_meth_free(_hidden_magma_ctr_acpkm_omac);
-        _hidden_magma_ctr_acpkm_omac = NULL;
-    }
-    return _hidden_magma_ctr_acpkm_omac;
-}
+GOST_cipher magma_ctr_acpkm_omac_cipher = {
+    .nid = NID_magma_ctr_acpkm_omac,
+    .block_size = 1,
+    .key_len = 32,
+    .iv_len = 4,
+    .flags = EVP_CIPH_CTR_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT |
+        EVP_CIPH_CUSTOM_COPY |
+        EVP_CIPH_FLAG_CUSTOM_CIPHER |
+        EVP_CIPH_FLAG_CIPHER_WITH_MAC,
+    .init = magma_cipher_init_ctr_acpkm_omac,
+    .do_cipher = magma_cipher_do_ctr_acpkm_omac,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = magma_cipher_ctl_acpkm_omac,
+};
 
 static EVP_CIPHER *_hidden_magma_cbc = NULL;
 const EVP_CIPHER *cipher_magma_cbc(void)

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -119,39 +119,23 @@ GOST_cipher Gost28147_89_cipher = {
     .ctrl = gost_cipher_ctl,
 };
 
-static EVP_CIPHER *_hidden_Gost28147_89_cbc = NULL;
-const EVP_CIPHER *cipher_gost_cbc(void)
-{
-    if (_hidden_Gost28147_89_cbc == NULL
-        && ((_hidden_Gost28147_89_cbc =
-             EVP_CIPHER_meth_new(NID_gost89_cbc, 8 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_Gost28147_89_cbc, 8)
-            || !EVP_CIPHER_meth_set_flags(_hidden_Gost28147_89_cbc,
-                                          EVP_CIPH_CBC_MODE |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_Gost28147_89_cbc,
-                                         gost_cipher_init_cbc)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_Gost28147_89_cbc,
-                                              gost_cipher_do_cbc)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_Gost28147_89_cbc,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_Gost28147_89_cbc,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_Gost28147_89_cbc,
-                                                    gost89_set_asn1_parameters)
-            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_Gost28147_89_cbc,
-                                                    gost89_get_asn1_parameters)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_Gost28147_89_cbc,
-                                         gost_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_Gost28147_89_cbc);
-        _hidden_Gost28147_89_cbc = NULL;
-    }
-    return _hidden_Gost28147_89_cbc;
-}
+GOST_cipher Gost28147_89_cbc_cipher = {
+    .nid = NID_gost89_cbc,
+    .block_size = 8,
+    .key_len = 32,
+    .iv_len = 8,
+    .flags = EVP_CIPH_CBC_MODE |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = gost_cipher_init_cbc,
+    .do_cipher = gost_cipher_do_cbc,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = gost_cipher_ctl,
+};
 
 static EVP_CIPHER *_hidden_gost89_cnt = NULL;
 const EVP_CIPHER *cipher_gost_cpacnt(void)
@@ -351,26 +335,6 @@ const EVP_CIPHER *cipher_magma_cbc(void)
         _hidden_magma_cbc = NULL;
     }
     return _hidden_magma_cbc;
-}
-
-void cipher_gost_destroy(void)
-{
-    //EVP_CIPHER_meth_free(_hidden_Gost28147_89_cipher);
-    //_hidden_Gost28147_89_cipher = NULL;
-    EVP_CIPHER_meth_free(_hidden_gost89_cnt);
-    _hidden_gost89_cnt = NULL;
-    EVP_CIPHER_meth_free(_hidden_Gost28147_89_cbc);
-    _hidden_Gost28147_89_cbc = NULL;
-    EVP_CIPHER_meth_free(_hidden_gost89_cnt_12);
-    _hidden_gost89_cnt_12 = NULL;
-    EVP_CIPHER_meth_free(_hidden_magma_cbc);
-    _hidden_magma_cbc = NULL;
-    EVP_CIPHER_meth_free(_hidden_magma_ctr);
-    _hidden_magma_ctr = NULL;
-    EVP_CIPHER_meth_free(_hidden_magma_ctr_acpkm);
-    _hidden_magma_ctr_acpkm = NULL;
-    EVP_CIPHER_meth_free(_hidden_magma_ctr_acpkm_omac);
-    _hidden_magma_ctr_acpkm_omac = NULL;
 }
 
 /* Implementation of GOST 28147-89 in MAC (imitovstavka) mode */

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -175,38 +175,24 @@ GOST_cipher Gost28147_89_cnt_12_cipher = {
     .ctrl = gost_cipher_ctl,
 };
 
-static EVP_CIPHER *_hidden_magma_ctr = NULL;
-const EVP_CIPHER *cipher_magma_ctr(void)
-{
-    if (_hidden_magma_ctr == NULL
-        && ((_hidden_magma_ctr =
-             EVP_CIPHER_meth_new(NID_magma_ctr, 1 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_magma_ctr, 4)
-            || !EVP_CIPHER_meth_set_flags(_hidden_magma_ctr,
-                                          EVP_CIPH_CTR_MODE |
-                                          EVP_CIPH_NO_PADDING |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_magma_ctr, magma_cipher_init)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_magma_ctr,
-                                              magma_cipher_do_ctr)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_magma_ctr,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_magma_ctr,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_magma_ctr,
-                                                    magma_set_asn1_parameters)
-            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_magma_ctr,
-                                                    magma_get_asn1_parameters)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_magma_ctr, magma_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_magma_ctr);
-        _hidden_magma_ctr = NULL;
-    }
-    return _hidden_magma_ctr;
-}
+GOST_cipher magma_ctr_cipher = {
+    .nid = NID_magma_ctr,
+    .block_size = 1,
+    .key_len = 32,
+    .iv_len = 4,
+    .flags = EVP_CIPH_CTR_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = magma_cipher_init,
+    .do_cipher = magma_cipher_do_ctr,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = magma_cipher_ctl,
+};
 
 static EVP_CIPHER *_hidden_magma_ctr_acpkm = NULL;
 const EVP_CIPHER *cipher_magma_ctr_acpkm(void)

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -235,33 +235,24 @@ GOST_cipher magma_ctr_acpkm_omac_cipher = {
     .ctrl = magma_cipher_ctl_acpkm_omac,
 };
 
-static EVP_CIPHER *_hidden_magma_cbc = NULL;
-const EVP_CIPHER *cipher_magma_cbc(void)
-{
-    if (_hidden_magma_cbc == NULL
-        && ((_hidden_magma_cbc =
-             EVP_CIPHER_meth_new(NID_magma_cbc, 8 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_magma_cbc, 8)
-            || !EVP_CIPHER_meth_set_flags(_hidden_magma_cbc,
-                                          EVP_CIPH_CBC_MODE |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_magma_cbc, magma_cipher_init)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_magma_cbc,
-                                              magma_cipher_do_cbc)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_magma_cbc,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_magma_cbc,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_magma_cbc, magma_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_magma_cbc);
-        _hidden_magma_cbc = NULL;
-    }
-    return _hidden_magma_cbc;
-}
+GOST_cipher magma_cbc_cipher = {
+    .nid = NID_magma_cbc,
+    .block_size = 8,
+    .key_len = 32,
+    .iv_len = 8,
+    .flags = EVP_CIPH_CBC_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = magma_cipher_init,
+    .do_cipher = magma_cipher_do_cbc,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = magma_cipher_ctl,
+};
 
 /* Implementation of GOST 28147-89 in MAC (imitovstavka) mode */
 /* Init functions which set specific parameters */

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -156,40 +156,24 @@ GOST_cipher Gost28147_89_cnt_cipher = {
     .ctrl = gost_cipher_ctl,
 };
 
-static EVP_CIPHER *_hidden_gost89_cnt_12 = NULL;
-const EVP_CIPHER *cipher_gost_cpcnt_12(void)
-{
-    if (_hidden_gost89_cnt_12 == NULL
-        && ((_hidden_gost89_cnt_12 =
-             EVP_CIPHER_meth_new(NID_gost89_cnt_12, 1 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_gost89_cnt_12, 8)
-            || !EVP_CIPHER_meth_set_flags(_hidden_gost89_cnt_12,
-                                          EVP_CIPH_OFB_MODE |
-                                          EVP_CIPH_NO_PADDING |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_gost89_cnt_12,
-                                         gost_cipher_init_cp_12)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_gost89_cnt_12,
-                                              gost_cipher_do_cnt)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_gost89_cnt_12,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_gost89_cnt_12,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_gost89_cnt_12,
-                                                    gost89_set_asn1_parameters)
-            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_gost89_cnt_12,
-                                                    gost89_get_asn1_parameters)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_gost89_cnt_12,
-                                         gost_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_gost89_cnt_12);
-        _hidden_gost89_cnt_12 = NULL;
-    }
-    return _hidden_gost89_cnt_12;
-}
+GOST_cipher Gost28147_89_cnt_12_cipher = {
+    .nid = NID_gost89_cnt_12,
+    .block_size = 1,
+    .key_len = 32,
+    .iv_len = 8,
+    .flags = EVP_CIPH_OFB_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = gost_cipher_init_cp_12,
+    .do_cipher = gost_cipher_do_cnt,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = gost_cipher_ctl,
+};
 
 static EVP_CIPHER *_hidden_magma_ctr = NULL;
 const EVP_CIPHER *cipher_magma_ctr(void)

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -194,39 +194,24 @@ GOST_cipher magma_ctr_cipher = {
     .ctrl = magma_cipher_ctl,
 };
 
-static EVP_CIPHER *_hidden_magma_ctr_acpkm = NULL;
-const EVP_CIPHER *cipher_magma_ctr_acpkm(void)
-{
-    if (_hidden_magma_ctr_acpkm == NULL
-        && ((_hidden_magma_ctr_acpkm =
-             EVP_CIPHER_meth_new(NID_magma_ctr_acpkm, 1 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_magma_ctr_acpkm, 4)
-            || !EVP_CIPHER_meth_set_flags(_hidden_magma_ctr_acpkm,
-                                          EVP_CIPH_CTR_MODE |
-                                          EVP_CIPH_NO_PADDING |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_magma_ctr_acpkm, magma_cipher_init)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_magma_ctr_acpkm,
-                                              magma_cipher_do_ctr)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_magma_ctr_acpkm,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_magma_ctr_acpkm,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_magma_ctr_acpkm,
-                                                    magma_set_asn1_parameters)
-            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_magma_ctr_acpkm,
-                                                    magma_get_asn1_parameters)
-
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_magma_ctr_acpkm, magma_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_magma_ctr_acpkm);
-        _hidden_magma_ctr_acpkm = NULL;
-    }
-    return _hidden_magma_ctr_acpkm;
-}
+GOST_cipher magma_ctr_acpkm_cipher = {
+    .nid = NID_magma_ctr_acpkm,
+    .block_size = 1,
+    .key_len = 32,
+    .iv_len = 4,
+    .flags = EVP_CIPH_CTR_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = magma_cipher_init,
+    .do_cipher = magma_cipher_do_ctr,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = magma_cipher_ctl,
+};
 
 static EVP_CIPHER *_hidden_magma_ctr_acpkm_omac = NULL;
 const EVP_CIPHER *cipher_magma_ctr_acpkm_omac(void)

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -1,6 +1,8 @@
 /**********************************************************************
- *                          gost_crypt.c                              *
+ *             gost_crypt.c - Initialize all ciphers                  *
+ *                                                                    *
  *             Copyright (c) 2005-2006 Cryptocom LTD                  *
+ *             Copyright (c) 2020 Chikunov Vitaly <vt@altlinux.org>   *
  *         This file is distributed under the same license as OpenSSL *
  *                                                                    *
  *       OpenSSL interface to GOST 28147-89 cipher functions          *
@@ -67,42 +69,55 @@ static int magma_get_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params);
 static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 static int magma_cipher_ctl_acpkm_omac(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 
-static EVP_CIPHER *_hidden_Gost28147_89_cipher = NULL;
-const EVP_CIPHER *cipher_gost(void)
+EVP_CIPHER *GOST_init_cipher(GOST_cipher *c)
 {
-    if (_hidden_Gost28147_89_cipher == NULL
-        && ((_hidden_Gost28147_89_cipher =
-             EVP_CIPHER_meth_new(NID_id_Gost28147_89, 1 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_Gost28147_89_cipher, 8)
-            || !EVP_CIPHER_meth_set_flags(_hidden_Gost28147_89_cipher,
-                                          EVP_CIPH_CFB_MODE |
-                                          EVP_CIPH_NO_PADDING |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_Gost28147_89_cipher,
-                                         gost_cipher_init)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_Gost28147_89_cipher,
-                                              gost_cipher_do_cfb)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_Gost28147_89_cipher,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_Gost28147_89_cipher,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            ||
-            !EVP_CIPHER_meth_set_set_asn1_params(_hidden_Gost28147_89_cipher,
-                                                 gost89_set_asn1_parameters)
-            ||
-            !EVP_CIPHER_meth_set_get_asn1_params(_hidden_Gost28147_89_cipher,
-                                                 gost89_get_asn1_parameters)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_Gost28147_89_cipher,
-                                         gost_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_Gost28147_89_cipher);
-        _hidden_Gost28147_89_cipher = NULL;
+    if (c->cipher)
+        return c->cipher;
+
+    EVP_CIPHER *cipher;
+    if (!(cipher = EVP_CIPHER_meth_new(c->nid, c->block_size, c->key_len))
+        || !EVP_CIPHER_meth_set_iv_length(cipher, c->iv_len)
+        || !EVP_CIPHER_meth_set_flags(cipher, c->flags)
+        || !EVP_CIPHER_meth_set_init(cipher, c->init)
+        || !EVP_CIPHER_meth_set_do_cipher(cipher, c->do_cipher)
+        || !EVP_CIPHER_meth_set_cleanup(cipher, c->cleanup)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(cipher, c->ctx_size)
+        || !EVP_CIPHER_meth_set_set_asn1_params(cipher, c->set_asn1_parameters)
+        || !EVP_CIPHER_meth_set_get_asn1_params(cipher, c->get_asn1_parameters)
+        || !EVP_CIPHER_meth_set_ctrl(cipher, c->ctrl)) {
+        EVP_CIPHER_meth_free(cipher);
+        cipher = NULL;
     }
-    return _hidden_Gost28147_89_cipher;
+    c->cipher = cipher;
+    return c->cipher;
 }
+
+void GOST_deinit_cipher(GOST_cipher *c)
+{
+    if (c->cipher) {
+        EVP_CIPHER_meth_free(c->cipher);
+        c->cipher = NULL;
+    }
+}
+
+GOST_cipher Gost28147_89_cipher = {
+    .nid = NID_id_Gost28147_89,
+    .block_size = 1,
+    .key_len = 32,
+    .iv_len = 8,
+    .flags = EVP_CIPH_CFB_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = gost_cipher_init,
+    .do_cipher = gost_cipher_do_cfb,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = gost_cipher_ctl,
+};
 
 static EVP_CIPHER *_hidden_Gost28147_89_cbc = NULL;
 const EVP_CIPHER *cipher_gost_cbc(void)
@@ -340,8 +355,8 @@ const EVP_CIPHER *cipher_magma_cbc(void)
 
 void cipher_gost_destroy(void)
 {
-    EVP_CIPHER_meth_free(_hidden_Gost28147_89_cipher);
-    _hidden_Gost28147_89_cipher = NULL;
+    //EVP_CIPHER_meth_free(_hidden_Gost28147_89_cipher);
+    //_hidden_Gost28147_89_cipher = NULL;
     EVP_CIPHER_meth_free(_hidden_gost89_cnt);
     _hidden_gost89_cnt = NULL;
     EVP_CIPHER_meth_free(_hidden_Gost28147_89_cbc);
@@ -1444,3 +1459,4 @@ int gost_imit_cleanup(EVP_MD_CTX *ctx)
     memset(EVP_MD_CTX_md_data(ctx), 0, sizeof(struct ossl_gost_imit_ctx));
     return 1;
 }
+/* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -137,39 +137,24 @@ GOST_cipher Gost28147_89_cbc_cipher = {
     .ctrl = gost_cipher_ctl,
 };
 
-static EVP_CIPHER *_hidden_gost89_cnt = NULL;
-const EVP_CIPHER *cipher_gost_cpacnt(void)
-{
-    if (_hidden_gost89_cnt == NULL
-        && ((_hidden_gost89_cnt =
-             EVP_CIPHER_meth_new(NID_gost89_cnt, 1 /* block_size */ ,
-                                 32 /* key_size */ )) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_gost89_cnt, 8)
-            || !EVP_CIPHER_meth_set_flags(_hidden_gost89_cnt,
-                                          EVP_CIPH_OFB_MODE |
-                                          EVP_CIPH_NO_PADDING |
-                                          EVP_CIPH_CUSTOM_IV |
-                                          EVP_CIPH_RAND_KEY |
-                                          EVP_CIPH_ALWAYS_CALL_INIT)
-            || !EVP_CIPHER_meth_set_init(_hidden_gost89_cnt,
-                                         gost_cipher_init_cpa)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_gost89_cnt,
-                                              gost_cipher_do_cnt)
-            || !EVP_CIPHER_meth_set_cleanup(_hidden_gost89_cnt,
-                                            gost_cipher_cleanup)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_gost89_cnt,
-                                                  sizeof(struct
-                                                         ossl_gost_cipher_ctx))
-            || !EVP_CIPHER_meth_set_set_asn1_params(_hidden_gost89_cnt,
-                                                    gost89_set_asn1_parameters)
-            || !EVP_CIPHER_meth_set_get_asn1_params(_hidden_gost89_cnt,
-                                                    gost89_get_asn1_parameters)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_gost89_cnt, gost_cipher_ctl))) {
-        EVP_CIPHER_meth_free(_hidden_gost89_cnt);
-        _hidden_gost89_cnt = NULL;
-    }
-    return _hidden_gost89_cnt;
-}
+GOST_cipher Gost28147_89_cnt_cipher = {
+    .nid = NID_gost89_cnt,
+    .block_size = 1,
+    .key_len = 32,
+    .iv_len = 8,
+    .flags = EVP_CIPH_OFB_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .init = gost_cipher_init_cpa,
+    .do_cipher = gost_cipher_do_cnt,
+    .cleanup = gost_cipher_cleanup,
+    .ctx_size = sizeof(struct ossl_gost_cipher_ctx),
+    .set_asn1_parameters = gost89_set_asn1_parameters,
+    .get_asn1_parameters = gost89_get_asn1_parameters,
+    .ctrl = gost_cipher_ctl,
+};
 
 static EVP_CIPHER *_hidden_gost89_cnt_12 = NULL;
 const EVP_CIPHER *cipher_gost_cpcnt_12(void)

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -162,7 +162,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_magma_ctr_acpkm,
-        cipher_magma_ctr_acpkm,
+        NULL,
+	&magma_ctr_acpkm_cipher,
     },
     {
         NID_magma_ctr_acpkm_omac,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -153,7 +153,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_magma_cbc,
-        cipher_magma_cbc,
+        NULL,
+	&magma_cbc_cipher,
     },
     {
         NID_magma_ctr,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -188,11 +188,13 @@ static struct gost_cipher_minfo {
     },
     {
         NID_magma_kexp15,
-        cipher_magma_wrap,
+        NULL,
+	&magma_kexp15_cipher,
     },
     {
         NID_kuznyechik_kexp15,
-        cipher_kuznyechik_wrap,
+        NULL,
+	&kuznyechik_kexp15_cipher
     },
     { 0 },
 };

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -118,7 +118,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_gost89_cnt,
-        cipher_gost_cpacnt,
+        NULL,
+	&Gost28147_89_cnt_cipher,
     },
     {
         NID_gost89_cnt_12,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -133,23 +133,28 @@ static struct gost_cipher_minfo {
     },
     {
         NID_grasshopper_ecb,
-        cipher_gost_grasshopper_ecb,
+        NULL,
+	&grasshopper_ecb_cipher,
     },
     {
         NID_grasshopper_cbc,
-        cipher_gost_grasshopper_cbc,
+        NULL,
+	&grasshopper_cbc_cipher,
     },
     {
         NID_grasshopper_cfb,
-        cipher_gost_grasshopper_cfb,
+        NULL,
+	&grasshopper_cfb_cipher,
     },
     {
         NID_grasshopper_ofb,
-        cipher_gost_grasshopper_ofb,
+        NULL,
+	&grasshopper_ofb_cipher,
     },
     {
         NID_grasshopper_ctr,
-        cipher_gost_grasshopper_ctr,
+        NULL,
+	&grasshopper_ctr_cipher,
     },
     {
         NID_magma_cbc,
@@ -172,12 +177,14 @@ static struct gost_cipher_minfo {
 	&magma_ctr_acpkm_omac_cipher,
     },
     {
-        NID_id_tc26_cipher_gostr3412_2015_kuznyechik_ctracpkm,
-        cipher_gost_grasshopper_ctracpkm,
+        NID_kuznyechik_ctr_acpkm,
+        NULL,
+	&grasshopper_ctr_acpkm_cipher,
     },
     {
         NID_kuznyechik_ctr_acpkm_omac,
-        cipher_gost_grasshopper_ctracpkm_omac,
+        NULL,
+	&grasshopper_ctr_acpkm_omac_cipher,
     },
     {
         NID_magma_kexp15,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -167,7 +167,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_magma_ctr_acpkm_omac,
-        cipher_magma_ctr_acpkm_omac,
+        NULL,
+	&magma_ctr_acpkm_omac_cipher,
     },
     {
         NID_id_tc26_cipher_gostr3412_2015_kuznyechik_ctracpkm,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -123,7 +123,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_gost89_cnt_12,
-        cipher_gost_cpcnt_12,
+        NULL,
+	&Gost28147_89_cnt_12_cipher,
     },
     {
         NID_gost89_cbc,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -157,7 +157,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_magma_ctr,
-        cipher_magma_ctr,
+        NULL,
+	&magma_ctr_cipher,
     },
     {
         NID_magma_ctr_acpkm,

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -126,7 +126,8 @@ static struct gost_cipher_minfo {
     },
     {
         NID_gost89_cbc,
-        cipher_gost_cbc,
+        NULL,
+	&Gost28147_89_cbc_cipher,
     },
     {
         NID_grasshopper_ecb,

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -1,5 +1,6 @@
 /*
  * Maxim Tishkov 2016
+ * Copyright (c) 2020 Vitaly Chikunov <vt@altlinux.org>
  * This file is distributed under the same license as OpenSSL
  */
 
@@ -44,6 +45,103 @@ struct GRASSHOPPER_CIPHER_PARAMS {
     int iv_size;
     bool padding;
     int extra_flags;
+};
+
+static GOST_cipher grasshopper_template_cipher = {
+    .block_size = GRASSHOPPER_BLOCK_SIZE,
+    .key_len = GRASSHOPPER_KEY_SIZE,
+    .flags = EVP_CIPH_RAND_KEY |
+        EVP_CIPH_ALWAYS_CALL_INIT,
+    .do_cipher = gost_grasshopper_cipher_do,
+    .cleanup = gost_grasshopper_cipher_cleanup,
+    .ctx_size = sizeof(gost_grasshopper_cipher_ctx),
+    .set_asn1_parameters = gost_grasshopper_set_asn1_parameters,
+    .get_asn1_parameters = gost_grasshopper_get_asn1_parameters,
+    .ctrl = gost_grasshopper_cipher_ctl,
+};
+
+GOST_cipher grasshopper_ecb_cipher = {
+    .nid = NID_grasshopper_ecb,
+    .template = &grasshopper_template_cipher,
+    .flags = EVP_CIPH_ECB_MODE,
+    .init = gost_grasshopper_cipher_init_ecb,
+    .do_cipher = gost_grasshopper_cipher_do_ecb,
+};
+
+GOST_cipher grasshopper_cbc_cipher = {
+    .nid = NID_grasshopper_cbc,
+    .template = &grasshopper_template_cipher,
+    .iv_len = 16,
+    .flags = EVP_CIPH_CBC_MODE |
+        EVP_CIPH_CUSTOM_IV,
+    .init = gost_grasshopper_cipher_init_cbc,
+    .do_cipher = gost_grasshopper_cipher_do_cbc,
+};
+
+GOST_cipher grasshopper_ofb_cipher = {
+    .nid = NID_grasshopper_ofb,
+    .template = &grasshopper_template_cipher,
+    .block_size = 1,
+    .iv_len = 16,
+    .flags = EVP_CIPH_OFB_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV,
+    .init = gost_grasshopper_cipher_init_ofb,
+    .do_cipher = gost_grasshopper_cipher_do_ofb,
+};
+
+GOST_cipher grasshopper_cfb_cipher = {
+    .nid = NID_grasshopper_cfb,
+    .template = &grasshopper_template_cipher,
+    .block_size = 1,
+    .iv_len = 16,
+    .flags = EVP_CIPH_CFB_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV,
+    .init = gost_grasshopper_cipher_init_cfb,
+    .do_cipher = gost_grasshopper_cipher_do_cfb,
+};
+
+GOST_cipher grasshopper_ctr_cipher = {
+    .nid = NID_grasshopper_ctr,
+    .template = &grasshopper_template_cipher,
+    .block_size = 1,
+    .iv_len = 8,
+    .flags = EVP_CIPH_CTR_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV,
+    .init = gost_grasshopper_cipher_init_ctr,
+    .do_cipher = gost_grasshopper_cipher_do_ctr,
+    .ctx_size = sizeof(gost_grasshopper_cipher_ctx_ctr),
+};
+
+GOST_cipher grasshopper_ctr_acpkm_cipher = {
+    .nid = NID_kuznyechik_ctr_acpkm,
+    .template = &grasshopper_template_cipher,
+    .block_size = 1,
+    .iv_len = 8,
+    .flags = EVP_CIPH_CTR_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV,
+    .init = gost_grasshopper_cipher_init_ctracpkm,
+    .do_cipher = gost_grasshopper_cipher_do_ctracpkm,
+    .ctx_size = sizeof(gost_grasshopper_cipher_ctx_ctr),
+};
+
+GOST_cipher grasshopper_ctr_acpkm_omac_cipher = {
+    .nid = NID_kuznyechik_ctr_acpkm_omac,
+    .template = &grasshopper_template_cipher,
+    .block_size = 1,
+    .iv_len = 8,
+    .flags = EVP_CIPH_CTR_MODE |
+        EVP_CIPH_NO_PADDING |
+        EVP_CIPH_CUSTOM_IV |
+        EVP_CIPH_FLAG_CUSTOM_CIPHER |
+        EVP_CIPH_FLAG_CIPHER_WITH_MAC |
+        EVP_CIPH_CUSTOM_COPY,
+    .init = gost_grasshopper_cipher_init_ctracpkm_omac,
+    .do_cipher = gost_grasshopper_cipher_do_ctracpkm_omac,
+    .ctx_size = sizeof(gost_grasshopper_cipher_ctx_ctr),
 };
 
 static struct GRASSHOPPER_CIPHER_PARAMS gost_cipher_params[7] = {
@@ -1069,3 +1167,4 @@ void cipher_gost_grasshopper_destroy(void)
     EVP_CIPHER_meth_free(gost_grasshopper_ciphers[GRASSHOPPER_CIPHER_CTRACPKMOMAC]);
     gost_grasshopper_ciphers[GRASSHOPPER_CIPHER_CTRACPKMOMAC] = NULL;
 }
+/* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_keyexpimp.c
+++ b/gost_keyexpimp.c
@@ -412,55 +412,28 @@ int wrap_ctrl (EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 	}
 }
 
-static EVP_CIPHER *hidden_magma_wrap_cipher, *hidden_kuznyechik_wrap_cipher;
+static GOST_cipher wrap_template_cipher = {
+    .key_len = GOSTKEYLEN * 2,
+    .flags = GOST_WRAP_FLAGS,
+    .ctx_size = sizeof(GOST_WRAP_CTX),
+    .ctrl = wrap_ctrl,
+};
 
-const EVP_CIPHER *cipher_magma_wrap(void)
-{
-	if (hidden_magma_wrap_cipher == NULL
-			&& ((hidden_magma_wrap_cipher =
-					EVP_CIPHER_meth_new(NID_magma_kexp15, 8 /* block_size */ ,
-						GOSTKEYLEN*2 /* key_size */ )) == NULL
-				|| !EVP_CIPHER_meth_set_iv_length(hidden_magma_wrap_cipher, 4)
-				|| !EVP_CIPHER_meth_set_flags(hidden_magma_wrap_cipher, GOST_WRAP_FLAGS)
-				|| !EVP_CIPHER_meth_set_init(hidden_magma_wrap_cipher, magma_wrap_init)
-				|| !EVP_CIPHER_meth_set_ctrl(hidden_magma_wrap_cipher, wrap_ctrl)
-				|| !EVP_CIPHER_meth_set_do_cipher(hidden_magma_wrap_cipher, magma_wrap_do)
-				|| !EVP_CIPHER_meth_set_impl_ctx_size(hidden_magma_wrap_cipher, sizeof(GOST_WRAP_CTX))
-				|| !EVP_add_cipher(hidden_magma_wrap_cipher)
-				)) {
-		EVP_CIPHER_meth_free(hidden_magma_wrap_cipher);
-		hidden_magma_wrap_cipher = NULL;
-	}
+GOST_cipher magma_kexp15_cipher = {
+    .template = &wrap_template_cipher,
+    .nid = NID_magma_kexp15,
+    .block_size = 8,
+    .iv_len = 4,
+    .init = magma_wrap_init,
+    .do_cipher = magma_wrap_do,
+};
 
-	return hidden_magma_wrap_cipher;
-}
-
-const EVP_CIPHER *cipher_kuznyechik_wrap(void)
-{
-	if (hidden_kuznyechik_wrap_cipher == NULL
-			&& ((hidden_kuznyechik_wrap_cipher =
-					EVP_CIPHER_meth_new(NID_kuznyechik_kexp15, 16 /* FIXME block_size */ ,
-						GOSTKEYLEN*2 /* key_size */ )) == NULL
-				|| !EVP_CIPHER_meth_set_iv_length(hidden_kuznyechik_wrap_cipher, 8)
-				|| !EVP_CIPHER_meth_set_flags(hidden_kuznyechik_wrap_cipher, GOST_WRAP_FLAGS)
-				|| !EVP_CIPHER_meth_set_init(hidden_kuznyechik_wrap_cipher, kuznyechik_wrap_init)
-				|| !EVP_CIPHER_meth_set_ctrl(hidden_kuznyechik_wrap_cipher, wrap_ctrl)
-				|| !EVP_CIPHER_meth_set_do_cipher(hidden_kuznyechik_wrap_cipher, kuznyechik_wrap_do)
-				|| !EVP_CIPHER_meth_set_impl_ctx_size(hidden_kuznyechik_wrap_cipher, sizeof(GOST_WRAP_CTX))
-				|| !EVP_add_cipher(hidden_kuznyechik_wrap_cipher)
-				)) {
-		EVP_CIPHER_meth_free(hidden_kuznyechik_wrap_cipher);
-		hidden_kuznyechik_wrap_cipher = NULL;
-	}
-
-	return hidden_kuznyechik_wrap_cipher;
-}
-
-void wrap_ciphers_destroy(void)
-{
-	EVP_CIPHER_meth_free(hidden_magma_wrap_cipher);
-	hidden_magma_wrap_cipher = NULL;
-
-	EVP_CIPHER_meth_free(hidden_kuznyechik_wrap_cipher);
-	hidden_kuznyechik_wrap_cipher = NULL;
-}
+GOST_cipher kuznyechik_kexp15_cipher = {
+    .template = &wrap_template_cipher,
+    .nid = NID_kuznyechik_kexp15,
+    .block_size = 16,
+    .iv_len = 8,
+    .init = kuznyechik_wrap_init,
+    .do_cipher = kuznyechik_wrap_do,
+};
+/* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -244,7 +244,6 @@ extern struct gost_cipher_info gost_cipher_list[];
 /* Find encryption params from ASN1_OBJECT */
 const struct gost_cipher_info *get_encryption_params(ASN1_OBJECT *obj);
 /* Implementation of GOST 28147-89 cipher in CFB and CNT modes */
-const EVP_CIPHER *cipher_gost();
 const EVP_CIPHER *cipher_gost_cbc();
 const EVP_CIPHER *cipher_gost_cpacnt();
 const EVP_CIPHER *cipher_gost_cpcnt_12();
@@ -319,4 +318,30 @@ int pack_sign_cp(ECDSA_SIG *s, int order, unsigned char *sig, size_t *siglen);
 /* Get private key as BIGNUM from both 34.10-2001 keys*/
 /* Returns pointer into EVP_PKEY structure */
 BIGNUM *gost_get0_priv_key(const EVP_PKEY *pkey);
+
+/* Struct describing cipher and used for init/deinit.*/
+struct gost_cipher_st {
+    int nid;
+    EVP_CIPHER *cipher;
+    int block_size;     /* (bytes) */
+    int key_len;        /* (bytes) */
+    int iv_len;
+    int flags;
+    int (*init) (EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                 const unsigned char *iv, int enc);
+    int (*do_cipher)(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                     const unsigned char *in, size_t inl);
+    int (*cleanup)(EVP_CIPHER_CTX *);
+    int ctx_size;
+    int (*set_asn1_parameters)(EVP_CIPHER_CTX *, ASN1_TYPE *);
+    int (*get_asn1_parameters)(EVP_CIPHER_CTX *, ASN1_TYPE *);
+    int (*ctrl)(EVP_CIPHER_CTX *, int type, int arg, void *ptr);
+};
+typedef struct gost_cipher_st GOST_cipher;
+
+EVP_CIPHER *GOST_init_cipher(GOST_cipher *c);
+void GOST_deinit_cipher(GOST_cipher *c);
+
+extern GOST_cipher Gost28147_89_cipher;
 #endif
+/* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -320,6 +320,7 @@ BIGNUM *gost_get0_priv_key(const EVP_PKEY *pkey);
 
 /* Struct describing cipher and used for init/deinit.*/
 struct gost_cipher_st {
+    struct gost_cipher_st *template; /* template struct */
     int nid;
     EVP_CIPHER *cipher;
     int block_size;     /* (bytes) */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -347,5 +347,6 @@ extern GOST_cipher Gost28147_89_cnt_cipher;
 extern GOST_cipher Gost28147_89_cnt_12_cipher;
 extern GOST_cipher magma_ctr_cipher;
 extern GOST_cipher magma_ctr_acpkm_cipher;
+extern GOST_cipher magma_ctr_acpkm_omac_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -350,5 +350,13 @@ extern GOST_cipher magma_ctr_cipher;
 extern GOST_cipher magma_ctr_acpkm_cipher;
 extern GOST_cipher magma_ctr_acpkm_omac_cipher;
 extern GOST_cipher magma_cbc_cipher;
+extern GOST_cipher grasshopper_ecb_cipher;
+extern GOST_cipher grasshopper_cbc_cipher;
+extern GOST_cipher grasshopper_cfb_cipher;
+extern GOST_cipher grasshopper_ofb_cipher;
+extern GOST_cipher grasshopper_ctr_cipher;
+extern GOST_cipher grasshopper_ctr_acpkm_cipher;
+extern GOST_cipher grasshopper_ctr_acpkm_omac_cipher;
+
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -357,6 +357,8 @@ extern GOST_cipher grasshopper_ofb_cipher;
 extern GOST_cipher grasshopper_ctr_cipher;
 extern GOST_cipher grasshopper_ctr_acpkm_cipher;
 extern GOST_cipher grasshopper_ctr_acpkm_omac_cipher;
+extern GOST_cipher magma_kexp15_cipher;
+extern GOST_cipher kuznyechik_kexp15_cipher;
 
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -244,7 +244,6 @@ extern struct gost_cipher_info gost_cipher_list[];
 /* Find encryption params from ASN1_OBJECT */
 const struct gost_cipher_info *get_encryption_params(ASN1_OBJECT *obj);
 /* Implementation of GOST 28147-89 cipher in CFB and CNT modes */
-const EVP_CIPHER *cipher_gost_cbc();
 const EVP_CIPHER *cipher_gost_cpacnt();
 const EVP_CIPHER *cipher_gost_cpcnt_12();
 const EVP_CIPHER *cipher_magma_cbc();
@@ -343,5 +342,6 @@ EVP_CIPHER *GOST_init_cipher(GOST_cipher *c);
 void GOST_deinit_cipher(GOST_cipher *c);
 
 extern GOST_cipher Gost28147_89_cipher;
+extern GOST_cipher Gost28147_89_cbc_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -346,5 +346,6 @@ extern GOST_cipher Gost28147_89_cbc_cipher;
 extern GOST_cipher Gost28147_89_cnt_cipher;
 extern GOST_cipher Gost28147_89_cnt_12_cipher;
 extern GOST_cipher magma_ctr_cipher;
+extern GOST_cipher magma_ctr_acpkm_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -343,5 +343,6 @@ void GOST_deinit_cipher(GOST_cipher *c);
 
 extern GOST_cipher Gost28147_89_cipher;
 extern GOST_cipher Gost28147_89_cbc_cipher;
+extern GOST_cipher Gost28147_89_cnt_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -345,5 +345,6 @@ extern GOST_cipher Gost28147_89_cipher;
 extern GOST_cipher Gost28147_89_cbc_cipher;
 extern GOST_cipher Gost28147_89_cnt_cipher;
 extern GOST_cipher Gost28147_89_cnt_12_cipher;
+extern GOST_cipher magma_ctr_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -344,5 +344,6 @@ void GOST_deinit_cipher(GOST_cipher *c);
 extern GOST_cipher Gost28147_89_cipher;
 extern GOST_cipher Gost28147_89_cbc_cipher;
 extern GOST_cipher Gost28147_89_cnt_cipher;
+extern GOST_cipher Gost28147_89_cnt_12_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -348,5 +348,6 @@ extern GOST_cipher Gost28147_89_cnt_12_cipher;
 extern GOST_cipher magma_ctr_cipher;
 extern GOST_cipher magma_ctr_acpkm_cipher;
 extern GOST_cipher magma_ctr_acpkm_omac_cipher;
+extern GOST_cipher magma_cbc_cipher;
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */


### PR DESCRIPTION
Register cipers using definition tables. Introduce `GOST_cipher` type.

o gost_eng: Rework (simplify) cipher registration
o gost_keyexpimp: Rework cipher registration
o gost_grasshopper_cipher: Remove redundant code
o gost_grasshopper_cipher: Rework cipher registration
o gost_crypt: Allow templates in GOST_cipher
o gost_crypt: Add magma_cbc_cipher
o gost_crypt: Add magma_ctr_acpkm_omac_cipher
o gost_crypt: Add magma_ctr_acpkm_cipher
o gost_crypt: Add magma_ctr_cipher
o gost_crypt: Add Gost28147_89_cnt_12_cipher
o gost_crypt: Add Gost28147_89_cnt_cipher
o gost_crypt: Add Gost28147_89_cbc_cipher
o gost_crypt: Rework cipher registration, add Gost28147_89_cipher
