### PR TITLE
Rework digest registrations using table method

### DIFF
--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -290,7 +290,7 @@ GOST_digest Gost28147_89_mac_12_digest = {
  * upon engine initialization
  */
 
-struct gost_cipher_info gost_cipher_list[] = {
+static struct gost_cipher_info gost_cipher_list[] = {
     /*- NID *//*
      * Subst block
      *//*
@@ -424,7 +424,7 @@ static int gost_cipher_init_cp_12(EVP_CIPHER_CTX *ctx,
 }
 
 /* Initializes EVP_CIPHER_CTX with default values */
-int gost_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+static int gost_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                      const unsigned char *iv, int enc)
 {
     return gost_cipher_init_param(ctx, key, iv, enc, NID_undef,
@@ -432,7 +432,7 @@ int gost_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 }
 
 /* Initializes EVP_CIPHER_CTX with default values */
-int gost_cipher_init_cbc(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+static int gost_cipher_init_cbc(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                          const unsigned char *iv, int enc)
 {
     return gost_cipher_init_param(ctx, key, iv, enc, NID_undef,
@@ -440,7 +440,7 @@ int gost_cipher_init_cbc(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 }
 
 /* Initializes EVP_CIPHER_CTX with default values */
-int magma_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+static int magma_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                       const unsigned char *iv, int enc)
 {
     struct ossl_gost_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -476,7 +476,7 @@ int magma_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 }
 
 /* Initializes EVP_CIPHER_CTX with default values */
-int magma_cipher_init_ctr_acpkm_omac(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+static int magma_cipher_init_ctr_acpkm_omac(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                       const unsigned char *iv, int enc)
 {
 	if (key) {
@@ -552,7 +552,7 @@ static void gost_cnt_next(void *ctx, unsigned char *iv, unsigned char *buf)
 }
 
 /* GOST encryption in CBC mode */
-int gost_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
+static int gost_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
                        const unsigned char *in, size_t inl)
 {
     unsigned char b[8];
@@ -589,7 +589,7 @@ int gost_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
 }
 
 /* MAGMA encryption in CBC mode */
-int magma_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
+static int magma_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
                         const unsigned char *in, size_t inl)
 {
     unsigned char b[8];
@@ -731,7 +731,7 @@ static int magma_cipher_do_ctr_acpkm_omac(EVP_CIPHER_CTX *ctx, unsigned char *ou
 	return inl;
 }
 /* GOST encryption in CFB mode */
-int gost_cipher_do_cfb(EVP_CIPHER_CTX *ctx, unsigned char *out,
+static int gost_cipher_do_cfb(EVP_CIPHER_CTX *ctx, unsigned char *out,
                        const unsigned char *in, size_t inl)
 {
     const unsigned char *in_ptr = in;
@@ -850,7 +850,7 @@ static int gost_cipher_do_cnt(EVP_CIPHER_CTX *ctx, unsigned char *out,
 }
 
 /* Cleaning up of EVP_CIPHER_CTX */
-int gost_cipher_cleanup(EVP_CIPHER_CTX *ctx)
+static int gost_cipher_cleanup(EVP_CIPHER_CTX *ctx)
 {
     struct ossl_gost_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
 		EVP_MD_CTX_free(c->omac_ctx);
@@ -860,7 +860,7 @@ int gost_cipher_cleanup(EVP_CIPHER_CTX *ctx)
 }
 
 /* Control function for gost cipher */
-int gost_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
+static int gost_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     switch (type) {
     case EVP_CTRL_RAND_KEY:
@@ -943,7 +943,7 @@ int gost_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 }
 
 /* Control function for gost cipher */
-int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
+static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     switch (type) {
     case EVP_CTRL_RAND_KEY:
@@ -1007,7 +1007,7 @@ static int magma_cipher_ctl_acpkm_omac(EVP_CIPHER_CTX *ctx, int type, int arg, v
 }
 
 /* Set cipher parameters from ASN1 structure */
-int gost89_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
+static int gost89_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 {
     int len = 0;
     unsigned char *buf = NULL;
@@ -1052,7 +1052,7 @@ int gost89_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 }
 
 /* Store parameters into ASN1 structure */
-int gost89_get_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
+static int gost89_get_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 {
     int len;
     GOST_CIPHER_PARAMS *gcp = NULL;
@@ -1164,7 +1164,7 @@ static void mac_block_mesh(struct ossl_gost_imit_ctx *c,
     c->count = c->count % 1024 + 8;
 }
 
-int gost_imit_update(EVP_MD_CTX *ctx, const void *data, size_t count)
+static int gost_imit_update(EVP_MD_CTX *ctx, const void *data, size_t count)
 {
     struct ossl_gost_imit_ctx *c = EVP_MD_CTX_md_data(ctx);
     const unsigned char *p = data;
@@ -1197,7 +1197,7 @@ int gost_imit_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     return 1;
 }
 
-int gost_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
+static int gost_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     struct ossl_gost_imit_ctx *c = EVP_MD_CTX_md_data(ctx);
     if (!c->key_set) {
@@ -1220,7 +1220,7 @@ int gost_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
     return 1;
 }
 
-int gost_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
+static int gost_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
 {
     switch (type) {
     case EVP_MD_CTRL_KEY_LEN:
@@ -1276,7 +1276,7 @@ int gost_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
     }
 }
 
-int gost_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
+static int gost_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     if (EVP_MD_CTX_md_data(to) && EVP_MD_CTX_md_data(from)) {
         memcpy(EVP_MD_CTX_md_data(to), EVP_MD_CTX_md_data(from),
@@ -1286,7 +1286,7 @@ int gost_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 }
 
 /* Clean up imit ctx */
-int gost_imit_cleanup(EVP_MD_CTX *ctx)
+static int gost_imit_cleanup(EVP_MD_CTX *ctx)
 {
     memset(EVP_MD_CTX_md_data(ctx), 0, sizeof(struct ossl_gost_imit_ctx));
     return 1;

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -256,69 +256,52 @@ static int gost_imit_cleanup(EVP_MD_CTX *ctx);
 /* Control function, knows how to set MAC key.*/
 static int gost_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr);
 
-static EVP_MD *_hidden_Gost28147_89_MAC_md = NULL;
-static EVP_MD *_hidden_Gost28147_89_12_MAC_md = NULL;
+GOST_digest Gost28147_89_MAC_digest = {
+    .nid = NID_id_Gost28147_89_MAC,
+    .result_size = 4,
+    .input_blocksize = 8,
+    .app_datasize = sizeof(struct ossl_gost_imit_ctx),
+    .flags = EVP_MD_FLAG_XOF,
+    .init = gost_imit_init_cpa,
+    .update = gost_imit_update,
+    .final = gost_imit_final,
+    .copy = gost_imit_copy,
+    .cleanup = gost_imit_cleanup,
+    .ctrl = gost_imit_ctrl,
+};
 
 EVP_MD *imit_gost_cpa(void)
 {
-    if (_hidden_Gost28147_89_MAC_md == NULL) {
-        EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_id_Gost28147_89_MAC, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 4)
-            || !EVP_MD_meth_set_input_blocksize(md, 8)
-            || !EVP_MD_meth_set_app_datasize(md,
-                                             sizeof(struct ossl_gost_imit_ctx))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
-            || !EVP_MD_meth_set_init(md, gost_imit_init_cpa)
-            || !EVP_MD_meth_set_update(md, gost_imit_update)
-            || !EVP_MD_meth_set_final(md, gost_imit_final)
-            || !EVP_MD_meth_set_copy(md, gost_imit_copy)
-            || !EVP_MD_meth_set_cleanup(md, gost_imit_cleanup)
-            || !EVP_MD_meth_set_ctrl(md, gost_imit_ctrl)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_Gost28147_89_MAC_md = md;
-    }
-    return _hidden_Gost28147_89_MAC_md;
+    return GOST_init_digest(&Gost28147_89_MAC_digest);
 }
 
 void imit_gost_cpa_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_Gost28147_89_MAC_md);
-    _hidden_Gost28147_89_MAC_md = NULL;
+    GOST_deinit_digest(&Gost28147_89_MAC_digest);
 }
+
+GOST_digest Gost28147_89_mac_12_digest = {
+    .nid = NID_gost_mac_12,
+    .result_size = 4,
+    .input_blocksize = 8,
+    .app_datasize = sizeof(struct ossl_gost_imit_ctx),
+    .flags = EVP_MD_FLAG_XOF,
+    .init = gost_imit_init_cp_12,
+    .update = gost_imit_update,
+    .final = gost_imit_final,
+    .copy = gost_imit_copy,
+    .cleanup = gost_imit_cleanup,
+    .ctrl = gost_imit_ctrl,
+};
 
 EVP_MD *imit_gost_cp_12(void)
 {
-    if (_hidden_Gost28147_89_12_MAC_md == NULL) {
-        EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_gost_mac_12, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 4)
-            || !EVP_MD_meth_set_input_blocksize(md, 8)
-            || !EVP_MD_meth_set_app_datasize(md,
-                                             sizeof(struct ossl_gost_imit_ctx))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
-            || !EVP_MD_meth_set_init(md, gost_imit_init_cp_12)
-            || !EVP_MD_meth_set_update(md, gost_imit_update)
-            || !EVP_MD_meth_set_final(md, gost_imit_final)
-            || !EVP_MD_meth_set_copy(md, gost_imit_copy)
-            || !EVP_MD_meth_set_cleanup(md, gost_imit_cleanup)
-            || !EVP_MD_meth_set_ctrl(md, gost_imit_ctrl)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_Gost28147_89_12_MAC_md = md;
-    }
-    return _hidden_Gost28147_89_12_MAC_md;
+    return GOST_init_digest(&Gost28147_89_mac_12_digest);
 }
 
 void imit_gost_cp_12_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_Gost28147_89_12_MAC_md);
-    _hidden_Gost28147_89_12_MAC_md = NULL;
+    GOST_deinit_digest(&Gost28147_89_mac_12_digest);
 }
 
 /*

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -270,16 +270,6 @@ GOST_digest Gost28147_89_MAC_digest = {
     .ctrl = gost_imit_ctrl,
 };
 
-EVP_MD *imit_gost_cpa(void)
-{
-    return GOST_init_digest(&Gost28147_89_MAC_digest);
-}
-
-void imit_gost_cpa_destroy(void)
-{
-    GOST_deinit_digest(&Gost28147_89_MAC_digest);
-}
-
 GOST_digest Gost28147_89_mac_12_digest = {
     .nid = NID_gost_mac_12,
     .result_size = 4,
@@ -293,16 +283,6 @@ GOST_digest Gost28147_89_mac_12_digest = {
     .cleanup = gost_imit_cleanup,
     .ctrl = gost_imit_ctrl,
 };
-
-EVP_MD *imit_gost_cp_12(void)
-{
-    return GOST_init_digest(&Gost28147_89_mac_12_digest);
-}
-
-void imit_gost_cp_12_destroy(void)
-{
-    GOST_deinit_digest(&Gost28147_89_mac_12_digest);
-}
 
 /*
  * Correspondence between gost parameter OIDs and substitution blocks

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -929,6 +929,7 @@ int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *pt
     return 1;
 }
 
+/* Called directly by CMAC_ACPKM_Init() */
 const GRASSHOPPER_INLINE EVP_CIPHER *cipher_gost_grasshopper_ctracpkm()
 {
     return GOST_init_cipher(&grasshopper_ctr_acpkm_cipher);

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -151,7 +151,7 @@ static void acpkm_next(gost_grasshopper_cipher_ctx * c)
 }
 
 /* Set 256 bit  key into context */
-GRASSHOPPER_INLINE void
+static GRASSHOPPER_INLINE void
 gost_grasshopper_cipher_key(gost_grasshopper_cipher_ctx * c, const uint8_t *k)
 {
     int i;
@@ -165,7 +165,7 @@ gost_grasshopper_cipher_key(gost_grasshopper_cipher_ctx * c, const uint8_t *k)
 }
 
 /* Set master 256-bit key to be used in TLSTREE calculation into context */
-GRASSHOPPER_INLINE void
+static GRASSHOPPER_INLINE void
 gost_grasshopper_master_key(gost_grasshopper_cipher_ctx * c, const uint8_t *k)
 {
     int i;
@@ -176,7 +176,7 @@ gost_grasshopper_master_key(gost_grasshopper_cipher_ctx * c, const uint8_t *k)
 }
 
 /* Cleans up key from context */
-GRASSHOPPER_INLINE void
+static GRASSHOPPER_INLINE void
 gost_grasshopper_cipher_destroy(gost_grasshopper_cipher_ctx * c)
 {
     int i;
@@ -205,7 +205,7 @@ gost_grasshopper_cipher_destroy_ctr(gost_grasshopper_cipher_ctx * c)
     grasshopper_zero128(&ctx->partial_buffer);
 }
 
-int gost_grasshopper_cipher_init(EVP_CIPHER_CTX *ctx,
+static int gost_grasshopper_cipher_init(EVP_CIPHER_CTX *ctx,
                                  const unsigned char *key,
                                  const unsigned char *iv, int enc)
 {
@@ -238,45 +238,50 @@ int gost_grasshopper_cipher_init(EVP_CIPHER_CTX *ctx,
     return 1;
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ecb(EVP_CIPHER_CTX *ctx, const unsigned char
-                                                        *key, const unsigned char
-                                                        *iv, int enc)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_cipher_init_ecb(EVP_CIPHER_CTX *ctx, const unsigned char
+                                 *key, const unsigned char
+                                 *iv, int enc)
 {
     gost_grasshopper_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
     c->type = GRASSHOPPER_CIPHER_ECB;
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_cbc(EVP_CIPHER_CTX *ctx, const unsigned char
-                                                        *key, const unsigned char
-                                                        *iv, int enc)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_cipher_init_cbc(EVP_CIPHER_CTX *ctx, const unsigned char
+                                 *key, const unsigned char
+                                 *iv, int enc)
 {
     gost_grasshopper_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
     c->type = GRASSHOPPER_CIPHER_CBC;
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ofb(EVP_CIPHER_CTX *ctx, const unsigned char
-                                                        *key, const unsigned char
-                                                        *iv, int enc)
+static GRASSHOPPER_INLINE
+int gost_grasshopper_cipher_init_ofb(EVP_CIPHER_CTX *ctx, const unsigned char
+                                     *key, const unsigned char
+                                     *iv, int enc)
 {
     gost_grasshopper_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
     c->type = GRASSHOPPER_CIPHER_OFB;
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_cfb(EVP_CIPHER_CTX *ctx, const unsigned char
-                                                        *key, const unsigned char
-                                                        *iv, int enc)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_cipher_init_cfb(EVP_CIPHER_CTX *ctx, const unsigned char
+                                 *key, const unsigned char
+                                 *iv, int enc)
 {
     gost_grasshopper_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
     c->type = GRASSHOPPER_CIPHER_CFB;
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ctr(EVP_CIPHER_CTX *ctx, const unsigned char
-                                                        *key, const unsigned char
-                                                        *iv, int enc)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_cipher_init_ctr(EVP_CIPHER_CTX *ctx, const unsigned char
+                                 *key, const unsigned char
+                                 *iv, int enc)
 {
     gost_grasshopper_cipher_ctx_ctr *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
 
@@ -288,10 +293,11 @@ GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ctr(EVP_CIPHER_CTX *ctx, con
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ctracpkm(EVP_CIPHER_CTX
-                                                             *ctx, const unsigned
-                                                             char *key, const unsigned
-                                                             char *iv, int enc)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_cipher_init_ctracpkm(EVP_CIPHER_CTX
+                                      *ctx, const unsigned
+                                      char *key, const unsigned
+                                      char *iv, int enc)
 {
     gost_grasshopper_cipher_ctx_ctr *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
 
@@ -303,10 +309,11 @@ GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ctracpkm(EVP_CIPHER_CTX
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX
-                                                             *ctx, const unsigned
-                                                             char *key, const unsigned
-                                                             char *iv, int enc)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX
+                                           *ctx, const unsigned
+                                           char *key, const unsigned
+                                           char *iv, int enc)
 {
 	gost_grasshopper_cipher_ctx_ctr *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
 
@@ -337,8 +344,8 @@ GRASSHOPPER_INLINE int gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX
 	return gost_grasshopper_cipher_init(ctx, key, iv, enc);
 }
 
-int gost_grasshopper_cipher_do_ecb(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                   const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_ecb(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                          const unsigned char *in, size_t inl)
 {
     gost_grasshopper_cipher_ctx *c =
         (gost_grasshopper_cipher_ctx *) EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -367,8 +374,8 @@ int gost_grasshopper_cipher_do_ecb(EVP_CIPHER_CTX *ctx, unsigned char *out,
     return 1;
 }
 
-int gost_grasshopper_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                   const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_cbc(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                          const unsigned char *in, size_t inl)
 {
     gost_grasshopper_cipher_ctx *c =
         (gost_grasshopper_cipher_ctx *) EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -428,8 +435,8 @@ static void ctr128_inc(unsigned char *counter)
     inc_counter(counter, 16);
 }
 
-int gost_grasshopper_cipher_do_ctr(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                   const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_ctr(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                          const unsigned char *in, size_t inl)
 {
     gost_grasshopper_cipher_ctx_ctr *c = (gost_grasshopper_cipher_ctx_ctr *)
         EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -497,9 +504,10 @@ static inline void apply_acpkm_grasshopper(gost_grasshopper_cipher_ctx_ctr *
 
 /* If meshing is not configured via ctrl (setting section_size)
  * this function works exactly like plain ctr */
-int gost_grasshopper_cipher_do_ctracpkm(EVP_CIPHER_CTX *ctx,
-                                        unsigned char *out,
-                                        const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_ctracpkm(EVP_CIPHER_CTX *ctx,
+                                               unsigned char *out,
+                                               const unsigned char *in,
+                                               size_t inl)
 {
     gost_grasshopper_cipher_ctx_ctr *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
     unsigned char *iv = EVP_CIPHER_CTX_iv_noconst(ctx);
@@ -547,9 +555,10 @@ int gost_grasshopper_cipher_do_ctracpkm(EVP_CIPHER_CTX *ctx,
     return inl;
 }
 
-int gost_grasshopper_cipher_do_ctracpkm_omac(EVP_CIPHER_CTX *ctx,
-                                        unsigned char *out,
-                                        const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_ctracpkm_omac(EVP_CIPHER_CTX *ctx,
+                                                    unsigned char *out,
+                                                    const unsigned char *in,
+                                                    size_t inl)
 {
 	int result;
   gost_grasshopper_cipher_ctx_ctr *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -587,8 +596,8 @@ static void gost_grasshopper_cnt_next(gost_grasshopper_cipher_ctx * ctx,
     memcpy(iv, buf, 16);
 }
 
-int gost_grasshopper_cipher_do_ofb(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                   const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_ofb(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                          const unsigned char *in, size_t inl)
 {
     gost_grasshopper_cipher_ctx *c = (gost_grasshopper_cipher_ctx *)
         EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -651,8 +660,8 @@ int gost_grasshopper_cipher_do_ofb(EVP_CIPHER_CTX *ctx, unsigned char *out,
     return 1;
 }
 
-int gost_grasshopper_cipher_do_cfb(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                                   const unsigned char *in, size_t inl)
+static int gost_grasshopper_cipher_do_cfb(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                                          const unsigned char *in, size_t inl)
 {
     gost_grasshopper_cipher_ctx *c =
         (gost_grasshopper_cipher_ctx *) EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -737,7 +746,7 @@ int gost_grasshopper_cipher_do_cfb(EVP_CIPHER_CTX *ctx, unsigned char *out,
     return 1;
 }
 
-int gost_grasshopper_cipher_cleanup(EVP_CIPHER_CTX *ctx)
+static int gost_grasshopper_cipher_cleanup(EVP_CIPHER_CTX *ctx)
 {
     gost_grasshopper_cipher_ctx *c =
         (gost_grasshopper_cipher_ctx *) EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -753,7 +762,7 @@ int gost_grasshopper_cipher_cleanup(EVP_CIPHER_CTX *ctx)
     return 1;
 }
 
-int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
+static int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 {
 	if (EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_CTR_MODE) {
 		gost_grasshopper_cipher_ctx_ctr *ctr = EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -767,9 +776,8 @@ int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 	return 0;
 }
 
-GRASSHOPPER_INLINE int gost_grasshopper_get_asn1_parameters(EVP_CIPHER_CTX
-                                                            *ctx, ASN1_TYPE
-                                                            *params)
+static GRASSHOPPER_INLINE int
+gost_grasshopper_get_asn1_parameters(EVP_CIPHER_CTX *ctx, ASN1_TYPE *params)
 {
 	if (EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_CTR_MODE) {
 		gost_grasshopper_cipher_ctx_ctr *ctr = EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -791,7 +799,7 @@ GRASSHOPPER_INLINE int gost_grasshopper_get_asn1_parameters(EVP_CIPHER_CTX
 	return 0;
 }
 
-int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
+static int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     switch (type) {
     case EVP_CTRL_RAND_KEY:{

--- a/gost_grasshopper_cipher.h
+++ b/gost_grasshopper_cipher.h
@@ -35,56 +35,65 @@ typedef struct {
 		EVP_MD_CTX *omac_ctx;
 } gost_grasshopper_cipher_ctx_ctr;
 
-void gost_grasshopper_cipher_key(gost_grasshopper_cipher_ctx* c, const uint8_t* k);
+static void gost_grasshopper_cipher_key(gost_grasshopper_cipher_ctx* c, const uint8_t* k);
 
-void gost_grasshopper_cipher_destroy(gost_grasshopper_cipher_ctx* c);
+static void gost_grasshopper_cipher_destroy(gost_grasshopper_cipher_ctx* c);
 
-int gost_grasshopper_cipher_init_ecb(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_ecb(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init_cbc(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_cbc(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init_ofb(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_ofb(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init_cfb(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_cfb(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init_ctr(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_ctr(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init_ctracpkm(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_ctracpkm(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX* ctx,
+    const unsigned char* key, const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_init(EVP_CIPHER_CTX* ctx, const unsigned char* key,
-                                 const unsigned char* iv, int enc);
+static int gost_grasshopper_cipher_init(EVP_CIPHER_CTX* ctx, const unsigned char* key,
+    const unsigned char* iv, int enc);
 
-int gost_grasshopper_cipher_do(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                               const unsigned char* in, size_t inl);
+static int gost_grasshopper_cipher_do(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_cipher_do_ecb(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
+static int gost_grasshopper_cipher_do_ecb(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_cipher_do_cbc(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
+static int gost_grasshopper_cipher_do_cbc(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_cipher_do_ofb(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
+static int gost_grasshopper_cipher_do_ofb(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_cipher_do_cfb(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
+static int gost_grasshopper_cipher_do_cfb(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_cipher_do_ctr(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
-int gost_grasshopper_cipher_do_ctracpkm(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
-int gost_grasshopper_cipher_do_ctracpkm_omac(EVP_CIPHER_CTX* ctx, unsigned char* out,
-                                   const unsigned char* in, size_t inl);
+static int gost_grasshopper_cipher_do_ctr(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_cipher_cleanup(EVP_CIPHER_CTX* ctx);
+static int gost_grasshopper_cipher_do_ctracpkm(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX* ctx, ASN1_TYPE* params);
+static int gost_grasshopper_cipher_do_ctracpkm_omac(EVP_CIPHER_CTX* ctx, unsigned char* out,
+    const unsigned char* in, size_t inl);
 
-int gost_grasshopper_get_asn1_parameters(EVP_CIPHER_CTX* ctx, ASN1_TYPE* params);
+static int gost_grasshopper_cipher_cleanup(EVP_CIPHER_CTX* ctx);
 
-int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr);
+static int gost_grasshopper_set_asn1_parameters(EVP_CIPHER_CTX* ctx, ASN1_TYPE* params);
+
+static int gost_grasshopper_get_asn1_parameters(EVP_CIPHER_CTX* ctx, ASN1_TYPE* params);
+
+static int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr);
 
 const EVP_CIPHER* cipher_gost_grasshopper_ctracpkm();
 

--- a/gost_grasshopper_cipher.h
+++ b/gost_grasshopper_cipher.h
@@ -35,14 +35,6 @@ typedef struct {
 		EVP_MD_CTX *omac_ctx;
 } gost_grasshopper_cipher_ctx_ctr;
 
-typedef int (* grasshopper_init_cipher_func)(EVP_CIPHER_CTX* ctx, const unsigned char* key, const unsigned char* iv,
-                                             int enc);
-
-typedef int (* grasshopper_do_cipher_func)(EVP_CIPHER_CTX* ctx, unsigned char* out, const unsigned char* in,
-                                           size_t inl);
-
-typedef void (* grasshopper_destroy_cipher_func)(gost_grasshopper_cipher_ctx* c);
-
 void gost_grasshopper_cipher_key(gost_grasshopper_cipher_ctx* c, const uint8_t* k);
 
 void gost_grasshopper_cipher_destroy(gost_grasshopper_cipher_ctx* c);
@@ -94,21 +86,7 @@ int gost_grasshopper_get_asn1_parameters(EVP_CIPHER_CTX* ctx, ASN1_TYPE* params)
 
 int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr);
 
-EVP_CIPHER* cipher_gost_grasshopper_create(int cipher_type, int block_size);
-
-const int cipher_gost_grasshopper_setup(EVP_CIPHER* cipher, uint8_t mode, int iv_size, bool padding, int extra_flags);
-
-const EVP_CIPHER* cipher_gost_grasshopper(uint8_t mode, uint8_t num);
-
-extern const EVP_CIPHER* cipher_gost_grasshopper_ecb();
-extern const EVP_CIPHER* cipher_gost_grasshopper_cbc();
-extern const EVP_CIPHER* cipher_gost_grasshopper_ofb();
-extern const EVP_CIPHER* cipher_gost_grasshopper_cfb();
-extern const EVP_CIPHER* cipher_gost_grasshopper_ctr();
-extern const EVP_CIPHER* cipher_gost_grasshopper_ctracpkm();
-extern const EVP_CIPHER* cipher_gost_grasshopper_ctracpkm_omac();
-
-void cipher_gost_grasshopper_destroy(void);
+const EVP_CIPHER* cipher_gost_grasshopper_ctracpkm();
 
 #if defined(__cplusplus)
 }

--- a/gost_keyexpimp.c
+++ b/gost_keyexpimp.c
@@ -407,7 +407,7 @@ static int kuznyechik_wrap_do(EVP_CIPHER_CTX *ctx, unsigned char *out,
 	}
 }
 
-int wrap_ctrl (EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
+static int wrap_ctrl (EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
 	switch(type)
 	{

--- a/gost_keyexpimp.c
+++ b/gost_keyexpimp.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2019 Dmitry Belyavskiy <beldmit@gmail.com>
+ * Copyright (c) 2020 Vitaly Chikunov <vt@altlinux.org>
+ *
+ * Contents licensed under the terms of the OpenSSL license
+ * See https://www.openssl.org/source/license.html for details
+ */
 #ifdef _WIN32
 #include <winsock.h>
 #else

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -360,5 +360,27 @@ extern GOST_cipher grasshopper_ctr_acpkm_omac_cipher;
 extern GOST_cipher magma_kexp15_cipher;
 extern GOST_cipher kuznyechik_kexp15_cipher;
 
+struct gost_digest_st {
+    struct gost_digest_st *template;
+    int nid;
+    EVP_MD *digest;
+    int result_size;
+    int input_blocksize;
+    int app_datasize;
+    int flags;
+    int (*init)(EVP_MD_CTX *ctx);
+    int (*update)(EVP_MD_CTX *ctx, const void *data, size_t count);
+    int (*final)(EVP_MD_CTX *ctx, unsigned char *md);
+    int (*copy)(EVP_MD_CTX *to, const EVP_MD_CTX *from);
+    int (*cleanup)(EVP_MD_CTX *ctx);
+    int (*ctrl)(EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
+};
+typedef struct gost_digest_st GOST_digest;
+
+EVP_MD *GOST_init_digest(GOST_digest *d);
+void GOST_deinit_digest(GOST_digest *d);
+
+extern GOST_digest GostR3411_94_digest;
+
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -363,6 +363,7 @@ extern GOST_cipher kuznyechik_kexp15_cipher;
 struct gost_digest_st {
     struct gost_digest_st *template;
     int nid;
+    const char *alias;
     EVP_MD *digest;
     int result_size;
     int input_blocksize;

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -3,9 +3,10 @@
 /**********************************************************************
  *                        gost_lcl.h                                  *
  *             Copyright (c) 2006 Cryptocom LTD                       *
+ *             Copyright (c) 2020 Vitaly Chikunov <vt@altlinux.org>   *
  *       This file is distributed under the same license as OpenSSL   *
  *                                                                    *
- *         Internal declarations  used in GOST engine                *
+ *         Internal declarations  used in GOST engine                 *
  *         OpenSSL 0.9.9 libraries required to compile and use        *
  *                              this code                             *
  **********************************************************************/

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -382,6 +382,13 @@ EVP_MD *GOST_init_digest(GOST_digest *d);
 void GOST_deinit_digest(GOST_digest *d);
 
 extern GOST_digest GostR3411_94_digest;
+extern GOST_digest Gost28147_89_MAC_digest;
+extern GOST_digest Gost28147_89_mac_12_digest;
+extern GOST_digest GostR3411_2012_256_digest;
+extern GOST_digest GostR3411_2012_512_digest;
+extern GOST_digest magma_mac_digest;
+extern GOST_digest grasshopper_mac_digest;
+extern GOST_digest kuznyechik_ctracpkm_omac_digest;
 
 #endif
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -194,25 +194,6 @@ struct ossl_gost_digest_ctx {
     gost_hash_ctx dctx;
     gost_ctx cctx;
 };
-/* EVP_MD structure for GOST R 34.11 */
-EVP_MD *digest_gost(void);
-void digest_gost_destroy(void);
-/* EVP MD structure for GOST R 34.11-2012 algorithms */
-EVP_MD *digest_gost2012_256(void);
-EVP_MD *digest_gost2012_512(void);
-void digest_gost2012_256_destroy(void);
-void digest_gost2012_512_destroy(void);
-/* EVP_MD structure for GOST 28147 in MAC mode */
-EVP_MD *imit_gost_cpa(void);
-void imit_gost_cpa_destroy(void);
-EVP_MD *imit_gost_cp_12(void);
-void imit_gost_cp_12_destroy(void);
-EVP_MD *magma_omac(void);
-void magma_omac_destroy(void);
-EVP_MD *grasshopper_omac(void);
-EVP_MD *grasshopper_omac_acpkm(void);
-void grasshopper_omac_destroy(void);
-void grasshopper_omac_acpkm_destroy(void);
 /* Cipher context used for EVP_CIPHER operation */
 struct ossl_gost_cipher_ctx {
     int paramNID;
@@ -240,21 +221,8 @@ struct ossl_gost_imit_ctx {
     int key_set;
     int dgst_size;
 };
-/* Table which maps parameter NID to S-blocks */
-extern struct gost_cipher_info gost_cipher_list[];
 /* Find encryption params from ASN1_OBJECT */
 const struct gost_cipher_info *get_encryption_params(ASN1_OBJECT *obj);
-/* Implementation of GOST 28147-89 cipher in CFB and CNT modes */
-const EVP_CIPHER *cipher_gost_cpacnt();
-const EVP_CIPHER *cipher_gost_cpcnt_12();
-const EVP_CIPHER *cipher_magma_cbc();
-const EVP_CIPHER *cipher_magma_ctr();
-const EVP_CIPHER *cipher_magma_ctr_acpkm();
-const EVP_CIPHER *cipher_magma_ctr_acpkm_omac();
-const EVP_CIPHER *cipher_magma_wrap();
-const EVP_CIPHER *cipher_kuznyechik_wrap();
-void cipher_gost_destroy();
-void wrap_ciphers_destroy();
 
 void inc_counter(unsigned char *counter, size_t counter_bytes);
 

--- a/gost_md.c
+++ b/gost_md.c
@@ -78,16 +78,6 @@ void GOST_deinit_digest(GOST_digest *d)
     d->digest = NULL;
 }
 
-EVP_MD *digest_gost(void)
-{
-    return GOST_init_digest(&GostR3411_94_digest);
-}
-
-void digest_gost_destroy(void)
-{
-    GOST_deinit_digest(&GostR3411_94_digest);
-}
-
 int gost_digest_init(EVP_MD_CTX *ctx)
 {
     struct ossl_gost_digest_ctx *c = EVP_MD_CTX_md_data(ctx);

--- a/gost_md.c
+++ b/gost_md.c
@@ -1,6 +1,7 @@
 /**********************************************************************
  *                          md_gost.c                                 *
  *             Copyright (c) 2005-2006 Cryptocom LTD                  *
+ *             Copyright (c) 2020 Vitaly Chikunov <vt@altlinux.org>   *
  *         This file is distributed under the same license as OpenSSL *
  *                                                                    *
  *       OpenSSL interface to GOST R 34.11-94 hash functions          *

--- a/gost_md.c
+++ b/gost_md.c
@@ -63,12 +63,16 @@ EVP_MD *GOST_init_digest(GOST_digest *d)
         EVP_MD_meth_free(md);
         md = NULL;
     }
+    if (md && d->alias)
+        EVP_add_digest_alias(EVP_MD_name(md), d->alias);
     d->digest = md;
     return md;
 }
 
 void GOST_deinit_digest(GOST_digest *d)
 {
+    if (d->alias)
+        EVP_delete_digest_alias(d->alias);
     EVP_MD_meth_free(d->digest);
     d->digest = NULL;
 }

--- a/gost_md.c
+++ b/gost_md.c
@@ -78,7 +78,7 @@ void GOST_deinit_digest(GOST_digest *d)
     d->digest = NULL;
 }
 
-int gost_digest_init(EVP_MD_CTX *ctx)
+static int gost_digest_init(EVP_MD_CTX *ctx)
 {
     struct ossl_gost_digest_ctx *c = EVP_MD_CTX_md_data(ctx);
     memset(&(c->dctx), 0, sizeof(gost_hash_ctx));
@@ -87,18 +87,18 @@ int gost_digest_init(EVP_MD_CTX *ctx)
     return 1;
 }
 
-int gost_digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
+static int gost_digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
 {
     return hash_block((gost_hash_ctx *) EVP_MD_CTX_md_data(ctx), data, count);
 }
 
-int gost_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
+static int gost_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     return finish_hash((gost_hash_ctx *) EVP_MD_CTX_md_data(ctx), md);
 
 }
 
-int gost_digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
+static int gost_digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     struct ossl_gost_digest_ctx *md_ctx = EVP_MD_CTX_md_data(to);
     if (EVP_MD_CTX_md_data(to) && EVP_MD_CTX_md_data(from)) {
@@ -109,7 +109,7 @@ int gost_digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
     return 1;
 }
 
-int gost_digest_cleanup(EVP_MD_CTX *ctx)
+static int gost_digest_cleanup(EVP_MD_CTX *ctx)
 {
     if (EVP_MD_CTX_md_data(ctx))
         memset(EVP_MD_CTX_md_data(ctx), 0,

--- a/gost_md2012.c
+++ b/gost_md2012.c
@@ -1,6 +1,7 @@
 /**********************************************************************
  *                          gost_md2012.c                             *
  *             Copyright (c) 2013 Cryptocom LTD.                      *
+ *             Copyright (c) 2020 Vitaly Chikunov <vt@altlinux.org>   *
  *         This file is distributed under the same license as OpenSSL *
  *                                                                    *
  *          GOST R 34.11-2012 interface to OpenSSL engine.            *

--- a/gost_md2012.c
+++ b/gost_md2012.c
@@ -11,6 +11,7 @@
 
 #include <openssl/evp.h>
 #include "gosthash2012.h"
+#include "gost_lcl.h"
 
 static int gost_digest_init512(EVP_MD_CTX *ctx);
 static int gost_digest_init256(EVP_MD_CTX *ctx);
@@ -27,67 +28,49 @@ static int gost_digest_ctrl_512(EVP_MD_CTX *ctx, int type, int arg,
 const char micalg_256[] = "gostr3411-2012-256";
 const char micalg_512[] = "gostr3411-2012-512";
 
-static EVP_MD *_hidden_GostR3411_2012_256_md = NULL;
-static EVP_MD *_hidden_GostR3411_2012_512_md = NULL;
+GOST_digest GostR3411_2012_template_digest = {
+    .input_blocksize = 64,
+    .app_datasize = sizeof(gost2012_hash_ctx),
+    .update = gost_digest_update,
+    .final = gost_digest_final,
+    .copy = gost_digest_copy,
+    .cleanup = gost_digest_cleanup,
+};
+
+GOST_digest GostR3411_2012_256_digest = {
+    .nid = NID_id_GostR3411_2012_256,
+    .template = &GostR3411_2012_template_digest,
+    .result_size = 32,
+    .init = gost_digest_init256,
+    .ctrl = gost_digest_ctrl_256,
+};
 
 EVP_MD *digest_gost2012_256(void)
 {
-    if (_hidden_GostR3411_2012_256_md == NULL) {
-        EVP_MD *md;
-
-        if ((md =
-             EVP_MD_meth_new(NID_id_GostR3411_2012_256, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 32)
-            || !EVP_MD_meth_set_input_blocksize(md, 64)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(gost2012_hash_ctx))
-            || !EVP_MD_meth_set_init(md, gost_digest_init256)
-            || !EVP_MD_meth_set_update(md, gost_digest_update)
-            || !EVP_MD_meth_set_final(md, gost_digest_final)
-            || !EVP_MD_meth_set_copy(md, gost_digest_copy)
-            || !EVP_MD_meth_set_ctrl(md, gost_digest_ctrl_256)
-            || !EVP_MD_meth_set_cleanup(md, gost_digest_cleanup)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_GostR3411_2012_256_md = md;
-    }
-    return _hidden_GostR3411_2012_256_md;
+    return GOST_init_digest(&GostR3411_2012_256_digest);
 }
 
 void digest_gost2012_256_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_GostR3411_2012_256_md);
-    _hidden_GostR3411_2012_256_md = NULL;
+    GOST_deinit_digest(&GostR3411_2012_256_digest);
 }
+
+GOST_digest GostR3411_2012_512_digest = {
+    .nid = NID_id_GostR3411_2012_512,
+    .template = &GostR3411_2012_template_digest,
+    .result_size = 64,
+    .init = gost_digest_init512,
+    .ctrl = gost_digest_ctrl_512,
+};
 
 EVP_MD *digest_gost2012_512(void)
 {
-    if (_hidden_GostR3411_2012_512_md == NULL) {
-        EVP_MD *md;
-
-        if ((md =
-             EVP_MD_meth_new(NID_id_GostR3411_2012_512, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 64)
-            || !EVP_MD_meth_set_input_blocksize(md, 64)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(gost2012_hash_ctx))
-            || !EVP_MD_meth_set_init(md, gost_digest_init512)
-            || !EVP_MD_meth_set_update(md, gost_digest_update)
-            || !EVP_MD_meth_set_final(md, gost_digest_final)
-            || !EVP_MD_meth_set_copy(md, gost_digest_copy)
-            || !EVP_MD_meth_set_ctrl(md, gost_digest_ctrl_512)
-            || !EVP_MD_meth_set_cleanup(md, gost_digest_cleanup)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_GostR3411_2012_512_md = md;
-    }
-    return _hidden_GostR3411_2012_512_md;
+    return GOST_init_digest(&GostR3411_2012_512_digest);
 }
 
 void digest_gost2012_512_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_GostR3411_2012_512_md);
-    _hidden_GostR3411_2012_512_md = NULL;
+    GOST_deinit_digest(&GostR3411_2012_512_digest);
 }
 
 static int gost_digest_init512(EVP_MD_CTX *ctx)

--- a/gost_md2012.c
+++ b/gost_md2012.c
@@ -39,6 +39,7 @@ GOST_digest GostR3411_2012_template_digest = {
 
 GOST_digest GostR3411_2012_256_digest = {
     .nid = NID_id_GostR3411_2012_256,
+    .alias = "streebog256",
     .template = &GostR3411_2012_template_digest,
     .result_size = 32,
     .init = gost_digest_init256,
@@ -57,6 +58,7 @@ void digest_gost2012_256_destroy(void)
 
 GOST_digest GostR3411_2012_512_digest = {
     .nid = NID_id_GostR3411_2012_512,
+    .alias = "streebog512",
     .template = &GostR3411_2012_template_digest,
     .result_size = 64,
     .init = gost_digest_init512,

--- a/gost_md2012.c
+++ b/gost_md2012.c
@@ -47,16 +47,6 @@ GOST_digest GostR3411_2012_256_digest = {
     .ctrl = gost_digest_ctrl_256,
 };
 
-EVP_MD *digest_gost2012_256(void)
-{
-    return GOST_init_digest(&GostR3411_2012_256_digest);
-}
-
-void digest_gost2012_256_destroy(void)
-{
-    GOST_deinit_digest(&GostR3411_2012_256_digest);
-}
-
 GOST_digest GostR3411_2012_512_digest = {
     .nid = NID_id_GostR3411_2012_512,
     .alias = "streebog512",
@@ -65,16 +55,6 @@ GOST_digest GostR3411_2012_512_digest = {
     .init = gost_digest_init512,
     .ctrl = gost_digest_ctrl_512,
 };
-
-EVP_MD *digest_gost2012_512(void)
-{
-    return GOST_init_digest(&GostR3411_2012_512_digest);
-}
-
-void digest_gost2012_512_destroy(void)
-{
-    GOST_deinit_digest(&GostR3411_2012_512_digest);
-}
 
 static int gost_digest_init512(EVP_MD_CTX *ctx)
 {

--- a/gost_omac.c
+++ b/gost_omac.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2019 Dmitry Belyavskiy <beldmit@gmail.com>
+ * Copyright (c) 2020 Vitaly Chikunov <vt@altlinux.org>
+ *
+ * Contents licensed under the terms of the OpenSSL license
+ * See https://www.openssl.org/source/license.html for details
+ */
 #include <string.h>
 #include <openssl/cmac.h>
 #include <openssl/conf.h>

--- a/gost_omac.c
+++ b/gost_omac.c
@@ -277,23 +277,3 @@ GOST_digest grasshopper_mac_digest = {
     .result_size = 16,
     .init = grasshopper_imit_init,
 };
-
-EVP_MD *magma_omac(void)
-{
-    return GOST_init_digest(&magma_mac_digest);
-}
-
-void magma_omac_destroy(void)
-{
-    GOST_deinit_digest(&magma_mac_digest);
-}
-
-EVP_MD *grasshopper_omac(void)
-{
-    return GOST_init_digest(&grasshopper_mac_digest);
-}
-
-void grasshopper_omac_destroy(void)
-{
-    GOST_deinit_digest(&grasshopper_mac_digest);
-}

--- a/gost_omac.c
+++ b/gost_omac.c
@@ -79,7 +79,7 @@ static int omac_imit_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     return CMAC_Update(c->cmac_ctx, data, count);
 }
 
-int omac_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
+static int omac_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     OMAC_CTX *c = EVP_MD_CTX_md_data(ctx);
     unsigned char mac[MAX_GOST_OMAC_SIZE];
@@ -96,7 +96,7 @@ int omac_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
     return 1;
 }
 
-int omac_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
+static int omac_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     OMAC_CTX *c_to = EVP_MD_CTX_md_data(to);
     const OMAC_CTX *c_from = EVP_MD_CTX_md_data(from);
@@ -123,7 +123,7 @@ int omac_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 }
 
 /* Clean up imit ctx */
-int omac_imit_cleanup(EVP_MD_CTX *ctx)
+static int omac_imit_cleanup(EVP_MD_CTX *ctx)
 {
     OMAC_CTX *c = EVP_MD_CTX_md_data(ctx);
 
@@ -153,6 +153,7 @@ static int omac_key(OMAC_CTX * c, const EVP_CIPHER *cipher,
     return 1;
 }
 
+/* Called directly by gost_kexp15() */
 int omac_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
 {
     switch (type) {

--- a/gost_omac.c
+++ b/gost_omac.c
@@ -246,66 +246,47 @@ int omac_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
     }
 }
 
-static EVP_MD *_hidden_magma_mac_md = NULL;
+static GOST_digest omac_template_digest = {
+    .input_blocksize = 8,
+    .app_datasize = sizeof(OMAC_CTX),
+    .flags = EVP_MD_FLAG_XOF,
+    .update = omac_imit_update,
+    .final = omac_imit_final,
+    .copy = omac_imit_copy,
+    .cleanup = omac_imit_cleanup,
+    .ctrl = omac_imit_ctrl,
+};
+
+GOST_digest magma_mac_digest = {
+    .nid = NID_magma_mac,
+    .template = &omac_template_digest,
+    .result_size = 8,
+    .init = magma_imit_init,
+};
+
+GOST_digest grasshopper_mac_digest = {
+    .nid = NID_grasshopper_mac,
+    .template = &omac_template_digest,
+    .result_size = 16,
+    .init = grasshopper_imit_init,
+};
 
 EVP_MD *magma_omac(void)
 {
-    if (_hidden_magma_mac_md == NULL) {
-        EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_magma_mac, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 8)
-            || !EVP_MD_meth_set_input_blocksize(md, 8)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(OMAC_CTX))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
-            || !EVP_MD_meth_set_init(md, magma_imit_init)
-            || !EVP_MD_meth_set_update(md, omac_imit_update)
-            || !EVP_MD_meth_set_final(md, omac_imit_final)
-            || !EVP_MD_meth_set_copy(md, omac_imit_copy)
-            || !EVP_MD_meth_set_cleanup(md, omac_imit_cleanup)
-            || !EVP_MD_meth_set_ctrl(md, omac_imit_ctrl)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_magma_mac_md = md;
-    }
-    return _hidden_magma_mac_md;
+    return GOST_init_digest(&magma_mac_digest);
 }
 
 void magma_omac_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_magma_mac_md);
-    _hidden_magma_mac_md = NULL;
+    GOST_deinit_digest(&magma_mac_digest);
 }
-
-static EVP_MD *_hidden_grasshopper_mac_md = NULL;
 
 EVP_MD *grasshopper_omac(void)
 {
-    if (_hidden_grasshopper_mac_md == NULL) {
-        EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_grasshopper_mac, NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, 16)
-            || !EVP_MD_meth_set_input_blocksize(md, 8)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(OMAC_CTX))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
-            || !EVP_MD_meth_set_init(md, grasshopper_imit_init)
-            || !EVP_MD_meth_set_update(md, omac_imit_update)
-            || !EVP_MD_meth_set_final(md, omac_imit_final)
-            || !EVP_MD_meth_set_copy(md, omac_imit_copy)
-            || !EVP_MD_meth_set_cleanup(md, omac_imit_cleanup)
-            || !EVP_MD_meth_set_ctrl(md, omac_imit_ctrl)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_grasshopper_mac_md = md;
-    }
-    return _hidden_grasshopper_mac_md;
+    return GOST_init_digest(&grasshopper_mac_digest);
 }
 
 void grasshopper_omac_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_grasshopper_mac_md);
-    _hidden_grasshopper_mac_md = NULL;
+    GOST_deinit_digest(&grasshopper_mac_digest);
 }

--- a/gost_omac_acpkm.c
+++ b/gost_omac_acpkm.c
@@ -357,7 +357,7 @@ int omac_acpkm_imit_final(EVP_MD_CTX *ctx, unsigned char *md)
     return 1;
 }
 
-int omac_acpkm_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
+static int omac_acpkm_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     OMAC_ACPKM_CTX *c_to = EVP_MD_CTX_md_data(to);
     const OMAC_ACPKM_CTX *c_from = EVP_MD_CTX_md_data(from);
@@ -383,7 +383,7 @@ int omac_acpkm_imit_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 }
 
 /* Clean up imit ctx */
-int omac_acpkm_imit_cleanup(EVP_MD_CTX *ctx)
+static int omac_acpkm_imit_cleanup(EVP_MD_CTX *ctx)
 {
     OMAC_ACPKM_CTX *c = EVP_MD_CTX_md_data(ctx);
 

--- a/gost_omac_acpkm.c
+++ b/gost_omac_acpkm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 vt@altlinux.org. All Rights Reserved.
+ * Copyright (C) 2018,2020 Vitaly Chikunov <vt@altlinux.org>. All Rights Reserved.
  * Copyright (c) 2010 The OpenSSL Project.  All rights reserved.
  *
  * Contents licensed under the terms of the OpenSSL license

--- a/gost_omac_acpkm.c
+++ b/gost_omac_acpkm.c
@@ -509,13 +509,3 @@ GOST_digest kuznyechik_ctracpkm_omac_digest = {
     .cleanup = omac_acpkm_imit_cleanup,
     .ctrl = omac_acpkm_imit_ctrl,
 };
-
-EVP_MD *grasshopper_omac_acpkm(void)
-{
-    return GOST_init_digest(&kuznyechik_ctracpkm_omac_digest);
-}
-
-void grasshopper_omac_acpkm_destroy(void)
-{
-    GOST_deinit_digest(&kuznyechik_ctracpkm_omac_digest);
-}

--- a/gost_omac_acpkm.c
+++ b/gost_omac_acpkm.c
@@ -496,36 +496,26 @@ int omac_acpkm_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
     }
 }
 
-static EVP_MD *_hidden_grasshopper_omac_acpkm_md = NULL;
+GOST_digest kuznyechik_ctracpkm_omac_digest = {
+    .nid = NID_id_tc26_cipher_gostr3412_2015_kuznyechik_ctracpkm_omac,
+    .result_size = MAX_GOST_OMAC_ACPKM_SIZE,
+    .input_blocksize = GRASSHOPPER_BLOCK_SIZE,
+    .app_datasize = sizeof(OMAC_ACPKM_CTX),
+    .flags = EVP_MD_FLAG_XOF,
+    .init = grasshopper_omac_acpkm_init,
+    .update = omac_acpkm_imit_update,
+    .final = omac_acpkm_imit_final,
+    .copy = omac_acpkm_imit_copy,
+    .cleanup = omac_acpkm_imit_cleanup,
+    .ctrl = omac_acpkm_imit_ctrl,
+};
 
 EVP_MD *grasshopper_omac_acpkm(void)
 {
-    if (_hidden_grasshopper_omac_acpkm_md == NULL) {
-        EVP_MD *md;
-
-        if ((md =
-             EVP_MD_meth_new(NID_id_tc26_cipher_gostr3412_2015_kuznyechik_ctracpkm_omac,
-              NID_undef)) == NULL
-            || !EVP_MD_meth_set_result_size(md, MAX_GOST_OMAC_ACPKM_SIZE)
-            || !EVP_MD_meth_set_input_blocksize(md, GRASSHOPPER_BLOCK_SIZE)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(OMAC_ACPKM_CTX))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_XOF)
-            || !EVP_MD_meth_set_init(md, grasshopper_omac_acpkm_init)
-            || !EVP_MD_meth_set_update(md, omac_acpkm_imit_update)
-            || !EVP_MD_meth_set_final(md, omac_acpkm_imit_final)
-            || !EVP_MD_meth_set_copy(md, omac_acpkm_imit_copy)
-            || !EVP_MD_meth_set_cleanup(md, omac_acpkm_imit_cleanup)
-            || !EVP_MD_meth_set_ctrl(md, omac_acpkm_imit_ctrl)) {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_grasshopper_omac_acpkm_md = md;
-    }
-    return _hidden_grasshopper_omac_acpkm_md;
+    return GOST_init_digest(&kuznyechik_ctracpkm_omac_digest);
 }
 
 void grasshopper_omac_acpkm_destroy(void)
 {
-    EVP_MD_meth_free(_hidden_grasshopper_omac_acpkm_md);
-    _hidden_grasshopper_omac_acpkm_md = NULL;
+    GOST_deinit_digest(&kuznyechik_ctracpkm_omac_digest);
 }


### PR DESCRIPTION
o gost_eng: Simplify digest registration
o gost_md: Rework alias support in digest registration
o gost_omac_acpkm: Rework registration of kuznyechik_ctracpkm_omac
o gost_omac: Rework registration of magma/kuznyechik OMAC digests
o gost_md2012: Add registration using GostR3411_2012_{256,512}_digest
o gost_crypt: Add Gost28147_89_MAC_digest, Gost28147_89_mac_12_digest
o gost_md: Rework digest registration, add GostR3411_94_digest