### PR TITLE
.travis.yml: Make Travis script fail early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ before_script:
   - cd ..
 
 script:
+  - set -e
   - mkdir build
   - cd build
   - cmake -DOPENSSL_ROOT_DIR=${PREFIX} -DOPENSSL_LIBRARIES=${PREFIX}/lib -DOPENSSL_ENGINES_DIR=${PREFIX}/engines ${ASAN} ..


### PR DESCRIPTION
Such as, no need to run tests if build failed.