### PR TITLE
Experimental fuzzers

### DIFF
--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+MODE	?= libFuzzer
+BUILD	?= ..
+
+ifeq ($(shell test -e $(BUILD)/libgost_core.a && echo 1),1)
+# engine should be already configured
+include $(BUILD)/CMakeFiles/gost_engine.dir/flags.make
+else
+$(error Compile engine first)
+endif
+
+LINK	= $(shell grep -o -e -Wl,-rpath.* $(BUILD)/CMakeFiles/gost_engine.dir/link.txt \
+	  | sed s/:/:$(BUILD)/ \
+	  | sed s,libgost_core.a,$(BUILD)\/\\0,)
+
+OPENSSL_ROOT_DIR = $(shell grep OPENSSL_ROOT_DIR: ${BUILD}/CMakeCache.txt | sed s/.*=// | sed s/./-DOPENSSL_ROOT_DIR=\\0/)
+
+EFLAGS	= -ggdb
+CFLAGS	= -ggdb -Wno-deprecated-declarations
+
+ifeq ($(MODE),honggfuzz)
+CC	= hfuzz-clang
+LD	= $(CC)
+HFUZZ_CC_ASAN = 1
+else ifeq ($(MODE),libFuzzer)
+CC	= clang
+LD	= $(CC)
+FLAGS	+= -fsanitize=address,fuzzer
+EFLAGS	+= -fsanitize=address
+else ifeq ($(MODE),afl)
+$(notice afl mode)
+CC	= afl-clang-fast
+LD	= afl-clang-fast++
+LDFLAGS	+= afl_driver.cpp
+else
+$(error unknown fuzzing mode)
+endif
+
+CFLAGS  += $(C_INCLUDES) $(FLAGS)
+LDFLAGS += $(FLAGS) $(LINK)
+
+cms: cms.o
+pkey: pkey.o
+x509: x509.o
+
+# Not just compile, but re-compile gost-engine.
+engine:
+	@rm -f $(BUILD)/CMakeCache.txt
+	@make -C$(BUILD) clean -s
+	cd $(BUILD); \
+	CFLAGS="$(EFLAGS)" HFUZZ_CC_ASAN=$(HFUZZ_CC_ASAN) CC=$(CC) \
+	cmake $(OPENSSL_ROOT_DIR) .
+	make -C$(BUILD) -j$(shell nproc) VERBOSE=1
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
+%: %.o
+	$(LD) $(LDFLAGS) $< $(LOADLIBES) $(LDLIBS) -o $@
+
+fuzz: pkey
+	mkdir -p input output
+	#honggfuzz -i input --output output --rlimit_stack 20000 -t 1 -- ./$<
+	honggfuzz -i input --output output --rlimit_core 11111111111 -- ./$<
+
+afl_driver.cpp:
+	wget https://raw.githubusercontent.com/llvm/llvm-project/master/compiler-rt/lib/fuzzer/afl/afl_driver.cpp
+
+clean:
+	rm -f pkey x509 cms *.o
+
+fuzzclean:
+	rm -f HF.sanitizer.log.* HONGGFUZZ.REPORT.TXT SIG*.fuzz fuzz*.log
+	find input/ output/ -name '*.cov' -delete
+
+.PHONY: distclean clean

--- a/fuzz/cms.c
+++ b/fuzz/cms.c
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Part of gost-engine fuzzing
+ *
+ * Copyright (C) 2020 Vitaly Chikunov <vt@altlinux.org>
+ *
+ * Based on openssl/fuzz/cms.c
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <openssl/engine.h>
+#include <openssl/cms.h>
+#include <openssl/err.h>
+
+#define T(e) ({ \
+    if (!(e)) {\
+        ERR_print_errors_fp(stderr);\
+        OpenSSLDie(__FILE__, __LINE__, #e);\
+    } \
+})
+
+ENGINE *eng;
+
+int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+	/* Initialize engine. */
+	OPENSSL_add_all_algorithms_conf();
+	CRYPTO_free_ex_index(0, -1);
+	ERR_load_crypto_strings();
+	T(eng = ENGINE_by_id("gost"));
+	T(ENGINE_init(eng));
+	T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t size)
+{
+
+	CMS_ContentInfo *cms;
+	BIO *mem;
+
+	if (size == 0)
+		return 0;
+	mem = BIO_new(BIO_s_mem());
+	T(BIO_write(mem, buf, size) == size);
+	cms = d2i_CMS_bio(mem, NULL);
+	if (cms) {
+		BIO *out = BIO_new(BIO_s_null());
+		i2d_CMS_bio(out, cms);
+		BIO_free(out);
+		CMS_ContentInfo_free(cms);
+	}
+	BIO_free(mem);
+	ERR_clear_error();
+	return 0;
+}

--- a/fuzz/gen-input.sh
+++ b/fuzz/gen-input.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -efu
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generate different input coprpora for fuzzing
+#
+# Copyright (C) 2020 Vitaly Chikunov <vt@altlinux.org>
+
+mkdir -p input/{cert,pkey,cms,pem}
+cd input
+
+log() {
+  echo + "$*"
+  eval "$@"
+}
+
+CA=test-ca.conf
+if [ ! -e $CA ]; then
+cat > $CA <<- EOF
+	[ req ]
+	distinguished_name = req_distinguished_name
+	prompt = no
+	string_mask = utf8only
+	x509_extensions = v3_ca
+
+	[ req_distinguished_name ]
+	O = TEST-CA
+	CN = TEST certificate signing key
+	emailAddress = ca@test
+
+	[ v3_ca ]
+	basicConstraints=CA:TRUE
+	subjectKeyIdentifier=hash
+	authorityKeyIdentifier=keyid:always,issuer
+EOF
+fi
+
+head -c 2000 /dev/urandom > test.dat
+
+for m in \
+  gost2001:0 \
+  gost2001:A \
+  gost2001:B \
+  gost2001:C \
+  gost2001:XA \
+  gost2001:XB \
+  gost2012_256:0 \
+  gost2012_256:A \
+  gost2012_256:B \
+  gost2012_256:C \
+  gost2012_256:XA \
+  gost2012_256:XB \
+  gost2012_256:TCA \
+  gost2012_256:TCB \
+  gost2012_256:TCC \
+  gost2012_256:TCD \
+  gost2012_512:A \
+  gost2012_512:B \
+  gost2012_512:C; do
+    IFS=':' read -r algo param <<< "$m"
+    log openssl req -nodes -x509 -utf8 -days 999 -batch \
+      -config $CA \
+      -newkey $algo \
+      -pkeyopt paramset:$param \
+      -out    pem/$algo-$param.crt \
+      -keyout pem/$algo-$param.key
+    # convert from PEM to DER
+    log openssl x509 -in pem/$algo-$param.crt -out cert/$algo-$param.crt -outform DER
+    log openssl pkey -in pem/$algo-$param.key -out pkey/$algo-$param.key -outform DER
+
+    log openssl cms -sign -in test.dat -text -out cms/sign_$algo-$param.cmsg -outform DER -signer pem/$algo-$param.crt -inkey pem/$algo-$param.key
+    log openssl cms -sign -in test.dat -text -out cms/sign_$algo-$param.msg -outform DER -signer pem/$algo-$param.crt -inkey pem/$algo-$param.key -nocerts
+    log openssl cms -sign -binary -in test.dat -out cms/sign_$algo-$param.dsig -outform DER -signer pem/$algo-$param.crt -inkey pem/$algo-$param.key
+done
+
+
+

--- a/fuzz/pkey.c
+++ b/fuzz/pkey.c
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Part of gost-engine fuzzing
+ *
+ * Copyright (C) 2020 Vitaly Chikunov <vt@altlinux.org>
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <openssl/engine.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+#include <openssl/asn1.h>
+
+#define T(e) ({ \
+    if (!(e)) {\
+        ERR_print_errors_fp(stderr);\
+        OpenSSLDie(__FILE__, __LINE__, #e);\
+    } \
+})
+
+ENGINE *eng;
+
+int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+	/* Initialize engine. */
+	OPENSSL_add_all_algorithms_conf();
+	CRYPTO_free_ex_index(0, -1);
+	ERR_load_crypto_strings();
+	T(eng = ENGINE_by_id("gost"));
+	T(ENGINE_init(eng));
+	T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t size)
+{
+	const uint8_t *b = buf;
+
+	EVP_PKEY *x = d2i_AutoPrivateKey(NULL, &b, size);
+
+	if (x) {
+		BIO *bio = BIO_new(BIO_s_null());
+		EVP_PKEY_print_private(bio, x, 0, NULL);
+		BIO_free(bio);
+		EVP_PKEY_free(x);
+	}
+
+	return 0;
+}

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Part of gost-engine fuzzing
+ *
+ * Copyright (C) 2020 Vitaly Chikunov <vt@altlinux.org>
+ *
+ * Based on honggfuzz/examples/openssl/x509.c
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <openssl/engine.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+#include <openssl/asn1.h>
+
+#define T(e) ({ \
+    if (!(e)) {\
+        ERR_print_errors_fp(stderr);\
+        OpenSSLDie(__FILE__, __LINE__, #e);\
+    } \
+})
+
+ENGINE *eng;
+
+int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+	/* Initialize engine. */
+	OPENSSL_add_all_algorithms_conf();
+	CRYPTO_free_ex_index(0, -1);
+	ERR_load_crypto_strings();
+	T(eng = ENGINE_by_id("gost"));
+	T(ENGINE_init(eng));
+	T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t size)
+{
+	const uint8_t *b = buf;
+	X509 *x = d2i_X509(NULL, &b, size);
+
+	if (x) {
+		BIO *o = BIO_new_fp(stdout, BIO_NOCLOSE);
+		X509_print_ex(o, x, XN_FLAG_RFC2253, X509_FLAG_COMPAT);
+
+		unsigned char *der = NULL;
+		i2d_X509(x, &der);
+		OPENSSL_free(der);
+		X509_free(x);
+		BIO_free(o);
+	} else {
+		fprintf(stderr, "%s", ERR_error_string(ERR_get_error(), NULL));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
- Currently, only libFuzzer is working as it should.
- Honggfuzz shows some abnormal behavior
- AFL doesn't work at all.

How it works:
- Compile engine, `cd fuzz`, `make engine` (re-compiles engine with ASan), `make cms` to compuile cms fuzzer.
- Run `./gen-input.sh` to create basic corpus
- Run `./cms input/cms`, (also, `./pkey input/pkey`, `./x509 input/cert`) to run fuzzer(s).
