### PR TITLE
GOST EC armv7 aarch64 fixes

### DIFF
--- a/ecp_id_GostR3410_2001_CryptoPro_A_ParamSet.c
+++ b/ecp_id_GostR3410_2001_CryptoPro_A_ParamSet.c
@@ -3249,9 +3249,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -3271,9 +3271,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -3293,8 +3293,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -3360,7 +3360,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -3436,7 +3436,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -3537,6 +3537,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_CryptoPro_A_ParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_CryptoPro_A_ParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -8123,9 +8124,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -8145,9 +8146,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -8167,8 +8168,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -8234,7 +8235,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -8310,7 +8311,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -8411,6 +8412,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_CryptoPro_A_ParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_CryptoPro_A_ParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_GostR3410_2001_CryptoPro_B_ParamSet.c
+++ b/ecp_id_GostR3410_2001_CryptoPro_B_ParamSet.c
@@ -3901,9 +3901,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -3923,9 +3923,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -3945,8 +3945,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4012,7 +4012,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4088,7 +4088,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -4199,6 +4199,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_CryptoPro_B_ParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_CryptoPro_B_ParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -11362,9 +11363,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -11384,9 +11385,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -11406,8 +11407,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -11473,7 +11474,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -11549,7 +11550,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -11660,6 +11661,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_CryptoPro_B_ParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_CryptoPro_B_ParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_GostR3410_2001_CryptoPro_C_ParamSet.c
+++ b/ecp_id_GostR3410_2001_CryptoPro_C_ParamSet.c
@@ -4559,9 +4559,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -4581,9 +4581,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -4603,8 +4603,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4670,7 +4670,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4746,7 +4746,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -4857,6 +4857,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_CryptoPro_C_ParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_CryptoPro_C_ParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -14915,9 +14916,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -14937,9 +14938,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -14959,8 +14960,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -15026,7 +15027,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -15102,7 +15103,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -15213,6 +15214,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_CryptoPro_C_ParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_CryptoPro_C_ParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_GostR3410_2001_TestParamSet.c
+++ b/ecp_id_GostR3410_2001_TestParamSet.c
@@ -3609,8 +3609,8 @@ static void point_double(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1, t2, t3, t4;
     /* constants */
-    const limb_t *b3 = const_b3;
     const limb_t *a = const_a;
+    const limb_t *b3 = const_b3;
     /* set pointers for legacy curve arith */
     const limb_t *X = P->X;
     const limb_t *Y = P->Y;
@@ -3664,8 +3664,8 @@ static void point_add_mixed(pt_prj_t *R, const pt_prj_t *Q, const pt_aff_t *P) {
     /* temporary variables */
     fe_t t0, t1, t2, t3, t4, t5;
     /* constants */
-    const limb_t *b3 = const_b3;
     const limb_t *a = const_a;
+    const limb_t *b3 = const_b3;
     /* set pointers for legacy curve arith */
     const limb_t *X1 = Q->X;
     const limb_t *Y1 = Q->Y;
@@ -3732,8 +3732,8 @@ static void point_add_proj(pt_prj_t *R, const pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1, t2, t3, t4, t5;
     /* constants */
-    const limb_t *b3 = const_b3;
     const limb_t *a = const_a;
+    const limb_t *b3 = const_b3;
     /* set pointers for legacy curve arith */
     const limb_t *X1 = Q->X;
     const limb_t *Y1 = Q->Y;
@@ -3834,9 +3834,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -3856,9 +3856,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -3878,8 +3878,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -3945,7 +3945,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4021,7 +4021,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -4129,6 +4129,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_TestParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_TestParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -10886,8 +10887,8 @@ static void point_double(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1, t2, t3, t4;
     /* constants */
-    const limb_t *a = const_a;
     const limb_t *b3 = const_b3;
+    const limb_t *a = const_a;
     /* set pointers for legacy curve arith */
     const limb_t *X = P->X;
     const limb_t *Y = P->Y;
@@ -10941,8 +10942,8 @@ static void point_add_mixed(pt_prj_t *R, const pt_prj_t *Q, const pt_aff_t *P) {
     /* temporary variables */
     fe_t t0, t1, t2, t3, t4, t5;
     /* constants */
-    const limb_t *a = const_a;
     const limb_t *b3 = const_b3;
+    const limb_t *a = const_a;
     /* set pointers for legacy curve arith */
     const limb_t *X1 = Q->X;
     const limb_t *Y1 = Q->Y;
@@ -11009,8 +11010,8 @@ static void point_add_proj(pt_prj_t *R, const pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1, t2, t3, t4, t5;
     /* constants */
-    const limb_t *a = const_a;
     const limb_t *b3 = const_b3;
+    const limb_t *a = const_a;
     /* set pointers for legacy curve arith */
     const limb_t *X1 = Q->X;
     const limb_t *Y1 = Q->Y;
@@ -11111,9 +11112,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -11133,9 +11134,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -11155,8 +11156,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -11222,7 +11223,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -11298,7 +11299,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -11406,6 +11407,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_GostR3410_2001_TestParamSet_to_bytes(outx, P.X);
     fiat_id_GostR3410_2001_TestParamSet_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_tc26_gost_3410_2012_256_paramSetA.c
+++ b/ecp_id_tc26_gost_3410_2012_256_paramSetA.c
@@ -3322,8 +3322,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1;
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     const limb_t *Z1 = P->Z;
@@ -3350,8 +3350,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;
@@ -3417,9 +3417,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -3439,9 +3439,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -3461,8 +3461,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -3536,7 +3536,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -3624,7 +3624,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -3736,6 +3736,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_tc26_gost_3410_2012_256_paramSetA_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -8463,8 +8464,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1;
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     const limb_t *Z1 = P->Z;
@@ -8491,8 +8492,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;
@@ -8558,9 +8559,9 @@ static int scalar_get_bit(const unsigned char in[32], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
+static void scalar_rwnaf(int8_t out[52], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 51; i++) {
@@ -8580,9 +8581,9 @@ static void scalar_rwnaf(char out[52], const unsigned char in[32]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[257], const unsigned char in[32]) {
+static void scalar_wnaf(int8_t out[257], const unsigned char in[32]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 257; i++) {
@@ -8602,8 +8603,8 @@ static void scalar_wnaf(char out[257], const unsigned char in[32]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
                               const unsigned char b[32], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[257] = {0};
-    char bnaf[257] = {0};
+    int8_t anaf[257] = {0};
+    int8_t bnaf[257] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -8677,7 +8678,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[32],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -8765,7 +8766,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[32]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[52] = {0};
+    int8_t rnaf[52] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -8877,6 +8878,7 @@ static void point_mul(unsigned char outx[32], unsigned char outy[32],
     fiat_id_tc26_gost_3410_2012_256_paramSetA_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_tc26_gost_3410_2012_512_paramSetA.c
+++ b/ecp_id_tc26_gost_3410_2012_512_paramSetA.c
@@ -4239,9 +4239,9 @@ static int scalar_get_bit(const unsigned char in[64], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
+static void scalar_rwnaf(int8_t out[103], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 102; i++) {
@@ -4261,9 +4261,9 @@ static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[513], const unsigned char in[64]) {
+static void scalar_wnaf(int8_t out[513], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 513; i++) {
@@ -4283,8 +4283,8 @@ static void scalar_wnaf(char out[513], const unsigned char in[64]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
                               const unsigned char b[64], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[513] = {0};
-    char bnaf[513] = {0};
+    int8_t anaf[513] = {0};
+    int8_t bnaf[513] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4350,7 +4350,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4426,7 +4426,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[64]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -4527,6 +4527,7 @@ static void point_mul(unsigned char outx[64], unsigned char outy[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetA_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_512_paramSetA_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -12195,9 +12196,9 @@ static int scalar_get_bit(const unsigned char in[64], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
+static void scalar_rwnaf(int8_t out[103], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 102; i++) {
@@ -12217,9 +12218,9 @@ static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[513], const unsigned char in[64]) {
+static void scalar_wnaf(int8_t out[513], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 513; i++) {
@@ -12239,8 +12240,8 @@ static void scalar_wnaf(char out[513], const unsigned char in[64]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
                               const unsigned char b[64], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[513] = {0};
-    char bnaf[513] = {0};
+    int8_t anaf[513] = {0};
+    int8_t bnaf[513] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -12306,7 +12307,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -12382,7 +12383,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[64]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -12483,6 +12484,7 @@ static void point_mul(unsigned char outx[64], unsigned char outy[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetA_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_512_paramSetA_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_tc26_gost_3410_2012_512_paramSetB.c
+++ b/ecp_id_tc26_gost_3410_2012_512_paramSetB.c
@@ -6469,9 +6469,9 @@ static int scalar_get_bit(const unsigned char in[64], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
+static void scalar_rwnaf(int8_t out[103], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 102; i++) {
@@ -6491,9 +6491,9 @@ static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[513], const unsigned char in[64]) {
+static void scalar_wnaf(int8_t out[513], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 513; i++) {
@@ -6513,8 +6513,8 @@ static void scalar_wnaf(char out[513], const unsigned char in[64]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
                               const unsigned char b[64], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[513] = {0};
-    char bnaf[513] = {0};
+    int8_t anaf[513] = {0};
+    int8_t bnaf[513] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -6580,7 +6580,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -6656,7 +6656,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[64]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -6767,6 +6767,7 @@ static void point_mul(unsigned char outx[64], unsigned char outy[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetB_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_512_paramSetB_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -21902,9 +21903,9 @@ static int scalar_get_bit(const unsigned char in[64], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
+static void scalar_rwnaf(int8_t out[103], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 102; i++) {
@@ -21924,9 +21925,9 @@ static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[513], const unsigned char in[64]) {
+static void scalar_wnaf(int8_t out[513], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 513; i++) {
@@ -21946,8 +21947,8 @@ static void scalar_wnaf(char out[513], const unsigned char in[64]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
                               const unsigned char b[64], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[513] = {0};
-    char bnaf[513] = {0};
+    int8_t anaf[513] = {0};
+    int8_t bnaf[513] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -22013,7 +22014,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -22089,7 +22090,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[64]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -22200,6 +22201,7 @@ static void point_mul(unsigned char outx[64], unsigned char outy[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetB_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_512_paramSetB_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 

--- a/ecp_id_tc26_gost_3410_2012_512_paramSetC.c
+++ b/ecp_id_tc26_gost_3410_2012_512_paramSetC.c
@@ -4128,8 +4128,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1;
     /* constants */
-    const limb_t *T = const_T;
     const limb_t *S = const_S;
+    const limb_t *T = const_T;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     const limb_t *Z1 = P->Z;
@@ -4156,8 +4156,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *T = const_T;
     const limb_t *S = const_S;
+    const limb_t *T = const_T;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;
@@ -4223,9 +4223,9 @@ static int scalar_get_bit(const unsigned char in[64], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
+static void scalar_rwnaf(int8_t out[103], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 102; i++) {
@@ -4245,9 +4245,9 @@ static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[513], const unsigned char in[64]) {
+static void scalar_wnaf(int8_t out[513], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 513; i++) {
@@ -4267,8 +4267,8 @@ static void scalar_wnaf(char out[513], const unsigned char in[64]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
                               const unsigned char b[64], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[513] = {0};
-    char bnaf[513] = {0};
+    int8_t anaf[513] = {0};
+    int8_t bnaf[513] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4342,7 +4342,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -4430,7 +4430,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[64]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -4542,6 +4542,7 @@ static void point_mul(unsigned char outx[64], unsigned char outy[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetC_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 
@@ -11977,8 +11978,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
     fe_t t0, t1;
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     const limb_t *Z1 = P->Z;
@@ -12005,8 +12006,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;
@@ -12072,9 +12073,9 @@ static int scalar_get_bit(const unsigned char in[64], int idx) {
  * {\pm 1, \pm 3, \pm 5, \pm 7, \pm 9, ...}
  * i.e. signed odd digits with _no zeroes_ -- that makes it "regular".
  */
-static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
+static void scalar_rwnaf(int8_t out[103], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = (in[0] & (DRADIX_WNAF - 1)) | 1;
     for (i = 0; i < 102; i++) {
@@ -12094,9 +12095,9 @@ static void scalar_rwnaf(char out[103], const unsigned char in[64]) {
  * Compute "textbook" wnaf representation of a scalar.
  * NB: not constant time
  */
-static void scalar_wnaf(char out[513], const unsigned char in[64]) {
+static void scalar_wnaf(int8_t out[513], const unsigned char in[64]) {
     int i;
-    char window, d;
+    int8_t window, d;
 
     window = in[0] & (DRADIX_WNAF - 1);
     for (i = 0; i < 513; i++) {
@@ -12116,8 +12117,8 @@ static void scalar_wnaf(char out[513], const unsigned char in[64]) {
 static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
                               const unsigned char b[64], const pt_aff_t *P) {
     int i, d, is_neg, is_inf = 1, flipped = 0;
-    char anaf[513] = {0};
-    char bnaf[513] = {0};
+    int8_t anaf[513] = {0};
+    int8_t bnaf[513] = {0};
     pt_prj_t Q;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -12191,7 +12192,7 @@ static void var_smul_wnaf_two(pt_aff_t *out, const unsigned char a[64],
 static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                            const pt_aff_t *P) {
     int i, j, d, diff, is_neg;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, lut;
     pt_prj_t precomp[DRADIX / 2];
 
@@ -12279,7 +12280,7 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
  */
 static void fixed_smul_cmb(pt_aff_t *out, const unsigned char scalar[64]) {
     int i, j, k, d, diff, is_neg = 0;
-    char rnaf[103] = {0};
+    int8_t rnaf[103] = {0};
     pt_prj_t Q, R;
     pt_aff_t lut;
 
@@ -12391,6 +12392,7 @@ static void point_mul(unsigned char outx[64], unsigned char outy[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetC_to_bytes(outx, P.X);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_to_bytes(outy, P.Y);
 }
+
 
 #include <openssl/ec.h>
 


### PR DESCRIPTION
`char` defaults to signed on x86/x64, but unsigned on ARM.

The ECCKiila unit tests were failing pretty much across the board. Our CI is x64 -- it was actually OpenSSL's CI that picked this up.

@luinxz found and fixed the ECCKiila defect (thanks!). This PR is just the resulting template changes.