### PR TITLE
Edwards map fix

### DIFF
--- a/ecp_id_tc26_gost_3410_2012_256_paramSetA.c
+++ b/ecp_id_tc26_gost_3410_2012_256_paramSetA.c
@@ -3320,10 +3320,10 @@ static void point_add_proj(pt_prj_t *R, const pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
-    fe_t t0, t1;
+    fe_t t0;
     /* constants */
-    const limb_t *T = const_T;
     const limb_t *S = const_S;
+    const limb_t *T = const_T;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     const limb_t *Z1 = P->Z;
@@ -3333,13 +3333,13 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     limb_t *Z3 = Q->Z;
 
     /* the curve arith formula */
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(t0, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_sub(t1, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(T3, S, t0);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(T3, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_sub(t0, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(T3, S, T3);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(Y3, Z1, T3);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(Z3, X3, t1);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(t1, t1, T);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(t0, T3, t1);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(Z3, X1, t0);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(t0, t0, T);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(t0, T3, t0);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(X3, X1, t0);
 }
 
@@ -3350,8 +3350,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *T = const_T;
     const limb_t *S = const_S;
+    const limb_t *T = const_T;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;
@@ -8462,7 +8462,7 @@ static void point_add_proj(pt_prj_t *R, const pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
-    fe_t t0, t1;
+    fe_t t0;
     /* constants */
     const limb_t *T = const_T;
     const limb_t *S = const_S;
@@ -8475,13 +8475,13 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     limb_t *Z3 = Q->Z;
 
     /* the curve arith formula */
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(t0, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_sub(t1, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(T3, S, t0);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(T3, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_sub(t0, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(T3, S, T3);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(Y3, Z1, T3);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(Z3, X3, t1);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(t1, t1, T);
-    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(t0, T3, t1);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(Z3, X1, t0);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(t0, t0, T);
+    fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_add(t0, T3, t0);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_carry_mul(X3, X1, t0);
 }
 

--- a/ecp_id_tc26_gost_3410_2012_512_paramSetC.c
+++ b/ecp_id_tc26_gost_3410_2012_512_paramSetC.c
@@ -4126,7 +4126,7 @@ static void point_add_proj(pt_prj_t *R, const pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
-    fe_t t0, t1;
+    fe_t t0;
     /* constants */
     const limb_t *S = const_S;
     const limb_t *T = const_T;
@@ -4139,13 +4139,13 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     limb_t *Z3 = Q->Z;
 
     /* the curve arith formula */
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(t0, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_sub(t1, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(T3, S, t0);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(T3, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_sub(t0, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(T3, S, T3);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(Y3, Z1, T3);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(Z3, X3, t1);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(t1, t1, T);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(t0, T3, t1);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(Z3, X1, t0);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(t0, t0, T);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(t0, T3, t0);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(X3, X1, t0);
 }
 
@@ -4156,8 +4156,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *S = const_S;
     const limb_t *T = const_T;
+    const limb_t *S = const_S;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;
@@ -11976,10 +11976,10 @@ static void point_add_proj(pt_prj_t *R, const pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     /* temporary variables */
-    fe_t t0, t1;
+    fe_t t0;
     /* constants */
-    const limb_t *T = const_T;
     const limb_t *S = const_S;
+    const limb_t *T = const_T;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     const limb_t *Z1 = P->Z;
@@ -11989,13 +11989,13 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
     limb_t *Z3 = Q->Z;
 
     /* the curve arith formula */
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(t0, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_sub(t1, Z1, Y1);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(T3, S, t0);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(T3, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_sub(t0, Z1, Y1);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(T3, S, T3);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(Y3, Z1, T3);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(Z3, X3, t1);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(t1, t1, T);
-    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(t0, T3, t1);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(Z3, X1, t0);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(t0, t0, T);
+    fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_add(t0, T3, t0);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_carry_mul(X3, X1, t0);
 }
 
@@ -12006,8 +12006,8 @@ static void point_edwards2legacy(pt_prj_t *Q, const pt_prj_t *P) {
  */
 static void point_legacy2edwards(pt_prj_t *Q, const pt_aff_t *P) {
     /* constants */
-    const limb_t *T = const_T;
     const limb_t *S = const_S;
+    const limb_t *T = const_T;
     const limb_t *X1 = P->X;
     const limb_t *Y1 = P->Y;
     limb_t *X3 = Q->X;


### PR DESCRIPTION
ECCKiila Changes from

https://gitlab.com/nisec/ecckiila/-/issues/2

https://gitlab.com/nisec/ecckiila/-/commit/7445ecabef77965743e0ae8d39d7433b07820be6

* X3 -> X1
* eliminate a temp variable

X3 = X1 as pointers is the reason this was still passing unit tests.
But that might not hold in future versions of ECCKiila, so fix it now.