### PR TITLE
Provide cmake test if alignment requirement is strict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,18 @@ if (ADDCARRY_U64)
   add_definitions(-DHAVE_ADDCARRY_U64)
 endif()
 
+check_c_source_runs("
+  int main(void) {
+    char buf[16] = { 0, 1, 2 };
+    int *p = buf + 1;
+    int *q = buf + 2;
+    return (*p == *q);
+  }
+  " RELAXED_ALIGNMENT)
+if (NOT RELAXED_ALIGNMENT)
+  add_definitions(-DSTRICT_ALIGNMENT)
+endif()
+
 set(BIN_DIRECTORY bin)
 
 # Same soversion as OpenSSL


### PR DESCRIPTION
This is based on AX_CHECK_ALIGNED_ACCESS_REQUIRED from autoconf-archive.

Note, that on some arches unaligned access behavior could be changed at
runtime via prctl(1). Also, unaligned memory access is still slower (and
very slow on some arches) even if it's not strictly required.

Можно для чего-нибудь использовать, если нужно.