### PR TITLE
disable gost key mask on gost94 digest steps due to performance issues

### DIFF
--- a/gost89.h
+++ b/gost89.h
@@ -60,6 +60,8 @@ void gostcrypt(gost_ctx * c, const byte * in, byte * out);
 void gostdecrypt(gost_ctx * c, const byte * in, byte * out);
 /* Set key into context */
 void gost_key(gost_ctx * c, const byte * k);
+/* Set key into context without key mask */
+void gost_key_nomask(gost_ctx * c, const byte * k);
 /* Set key into context */
 void magma_key(gost_ctx * c, const byte * k);
 /* Get key from context */


### PR DESCRIPTION
In gost94 digest every step set 4 temporary keys for gost89 with mask, but mask is needless here, there is not a real cipher key.  RAND_priv_bytes drops the performance.

With RAND_priv_bytes calls in digest:
$ time bin/gostsum ../../10M.bin
52a8d8b81c9da69da38500ddcbc3374341f8bf158e7531879eba8c8c199cea5b ../../10M.bin

real    0m3,353s
user    0m2,830s
sys     0m0,480s

Without RAND_priv_bytes calls in digest:
$ time bin/gostsum ../../10M.bin 
52a8d8b81c9da69da38500ddcbc3374341f8bf158e7531879eba8c8c199cea5b ../../10M.bin

real    0m0,530s
user    0m0,504s
sys     0m0,000s