### PR TITLE
CMakeLists.txt: Fix warning on gcc-9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,8 @@ endif()
 check_c_source_runs("
   int main(void) {
     char buf[16] = { 0, 1, 2 };
-    int *p = buf + 1;
-    int *q = buf + 2;
+    int *p = (int *)(buf + 1);
+    int *q = (int *)(buf + 2);
     return (*p == *q);
   }
   " RELAXED_ALIGNMENT)


### PR DESCRIPTION
/root/rpmbuild/BUILD/openssl-gost-engine-1.1.1/CMakeFiles/CMakeTmp/src.c:4:14: warning: initialization of 'int *' from incompatible pointer type 'char *' [-Wincompatible-pointer-types]
    4 |     int *p = buf + 1;
      |              ^~~
/root/rpmbuild/BUILD/openssl-gost-engine-1.1.1/CMakeFiles/CMakeTmp/src.c:5:14: warning: initialization of 'int *' from incompatible pointer type 'char *' [-Wincompatible-pointer-types]
    5 |     int *q = buf + 2;
      |              ^~~

Reported-by: Ilya Shipitsin <https://github.com/chipitsine>
Fixes: #288