### PR TITLE
ctrl function implementation for magma & kuznechik

### DIFF
--- a/gost89.c
+++ b/gost89.c
@@ -484,6 +484,10 @@ void magma_key(gost_ctx * c, const byte * k)
     }
 }
 
+void magma_master_key(gost_ctx *c, const byte *k) {
+    memcpy(c->master_key, k, sizeof(c->master_key));
+}
+
 /* Retrieve 256-bit gost89 key from context */
 void gost_get_key(gost_ctx * c, byte * k)
 {
@@ -520,6 +524,7 @@ void gost_init(gost_ctx * c, const gost_subst_block * b)
 /* Cleans up key from context */
 void gost_destroy(gost_ctx * c)
 {
+    OPENSSL_cleanse(c->master_key, sizeof(c->master_key));
     OPENSSL_cleanse(c->key, sizeof(c->key));
     OPENSSL_cleanse(c->mask, sizeof(c->mask));
 }

--- a/gost89.h
+++ b/gost89.h
@@ -33,6 +33,7 @@ typedef struct {
 
 /* Cipher context includes key and preprocessed  substitution block */
 typedef struct {
+    u4 master_key[8];
     u4 key[8];
     u4 mask[8];
     /* Constant s-boxes -- set up in gost_init(). */
@@ -64,6 +65,8 @@ void gost_key(gost_ctx * c, const byte * k);
 void gost_key_nomask(gost_ctx * c, const byte * k);
 /* Set key into context */
 void magma_key(gost_ctx * c, const byte * k);
+/* Set master 256-bit key to be used in TLSTREE calculation into context */
+void magma_master_key(gost_ctx *c, const byte *k);
 /* Get key from context */
 void gost_get_key(gost_ctx * c, byte * k);
 /* Set S-blocks into context */

--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -456,8 +456,10 @@ static int magma_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         }
     }
 
-    if (key)
+    if (key) {
         magma_key(&(c->cctx), key);
+        magma_master_key(&(c->cctx), key);
+    }
     if (iv) {
         memcpy((unsigned char *)EVP_CIPHER_CTX_original_iv(ctx), iv,
                EVP_CIPHER_CTX_iv_length(ctx));
@@ -944,6 +946,27 @@ static int gost_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     return 1;
 }
 
+/* Decrement 8-byte sequence if needed */
+int decrement_sequence(unsigned char *seq, int decrement) {
+    if (decrement < 0 || decrement > 1)
+        return 0; 
+    
+    int j;
+    if (decrement) {
+       for (j = 7; j >= 0; j--)
+            {
+                if (seq[j] != 0)
+                {
+                    seq[j]--;
+                    break;
+                }
+                else
+                    seq[j] = 0xFF;
+            }
+    }
+    return 1;
+}
+
 /* Control function for gost cipher */
 static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
@@ -971,6 +994,54 @@ static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             c->key_meshing = arg;
             return 1;
         }
+    case EVP_CTRL_TLSTREE:
+        {
+            unsigned char newkey[32];
+            int mode = EVP_CIPHER_CTX_mode(ctx);
+            struct ossl_gost_cipher_ctx *ctr_ctx = NULL;
+            gost_ctx *c = NULL;
+
+            unsigned char adjusted_iv[8];
+            unsigned char seq[8];
+            int j, carry, decrement_arg;
+            if (mode != EVP_CIPH_CTR_MODE)
+                return -1;
+
+            ctr_ctx = (struct ossl_gost_cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+            c = &(ctr_ctx->cctx);
+
+            /*
+             * 'arg' parameter indicates what we should do with sequence value.
+             * 
+             * When function called, seq is incremented after MAC calculation.
+             * In ETM mode, we use seq 'as is' in the ctrl-function (arg = 0)
+             * Otherwise we have to decrease it in the implementation (arg = 1).
+             */
+            memcpy(seq, ptr, 8);
+            decrement_arg = arg;
+            if(!decrement_sequence(seq, decrement_arg)) {
+                GOSTerr(GOST_F_MAGMA_CIPHER_CTL, GOST_R_CTRL_CALL_FAILED);
+                return -1;
+            }
+
+            if (gost_tlstree(NID_magma_cbc, (const unsigned char *)c->master_key, newkey,
+                             (const unsigned char *)seq) > 0) {
+                memset(adjusted_iv, 0, 8);
+                memcpy(adjusted_iv, EVP_CIPHER_CTX_original_iv(ctx), 4);
+                for (j = 3, carry = 0; j >= 0; j--)
+                {
+                    int adj_byte = adjusted_iv[j] + seq[j+4] + carry;
+                    carry = (adj_byte > 255) ? 1 : 0;
+                    adjusted_iv[j] = adj_byte & 0xFF;
+                }
+                EVP_CIPHER_CTX_set_num(ctx, 0);
+                memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), adjusted_iv, 8);
+
+                magma_key(c, newkey);
+                return 1;
+          }
+        }
+        return -1;
     default:
         GOSTerr(GOST_F_MAGMA_CIPHER_CTL, GOST_R_UNSUPPORTED_CIPHER_CTL_COMMAND);
         return -1;

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -305,6 +305,9 @@ int pack_sign_cp(ECDSA_SIG *s, int order, unsigned char *sig, size_t *siglen);
 /* Get private key as BIGNUM from both 34.10-2001 keys*/
 /* Returns pointer into EVP_PKEY structure */
 BIGNUM *gost_get0_priv_key(const EVP_PKEY *pkey);
+/* from gost_crypt.c */
+/* Decrements 8-byte sequence */ 
+int decrement_sequence(unsigned char *seq, int decrement);
 
 /* Struct describing cipher and used for init/deinit.*/
 struct gost_cipher_st {


### PR DESCRIPTION
implement EVP_CTRL_TLSTREE case for magma & kuznechik ctrl function.
some minor changes for storing master key in magma cipher, used for TLSTREE mode.