### PR TITLE
add magma and kuznetchik support for TLSTREE mode

### DIFF
--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -1224,6 +1224,27 @@ static int gost_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     return 1;
 }
 
+/* Decrement 8-byte sequence if needed */
+int decrement_sequence(unsigned char *seq, int decrement) {
+    if (decrement < 0 || decrement > 1)
+        return 0; 
+
+    int j;
+    if (decrement) {
+       for (j = 7; j >= 0; j--)
+            {
+                if (seq[j] != 0)
+                {
+                    seq[j]--;
+                    break;
+                }
+                else
+                    seq[j] = 0xFF;
+            }
+    }
+    return 1;
+}
+
 /* Control function for gost cipher */
 static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
@@ -1251,6 +1272,56 @@ static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             c->key_meshing = arg;
             return 1;
         }
+    case EVP_CTRL_TLSTREE:
+        {
+            unsigned char newkey[32];
+            int mode = EVP_CIPHER_CTX_mode(ctx);
+            struct ossl_gost_cipher_ctx *ctr_ctx = NULL;
+            gost_ctx *c = NULL;
+
+            unsigned char adjusted_iv[8];
+            unsigned char seq[8];
+            int j, carry, decrement_arg;
+            if (mode != EVP_CIPH_CTR_MODE)
+                return -1;
+
+            ctr_ctx = (struct ossl_gost_cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+            c = &(ctr_ctx->cctx);
+
+            /*
+             * 'arg' parameter indicates what we should do with sequence value.
+             * 
+             * When function called, seq is incremented after MAC calculation.
+             * In ETM mode, we use seq 'as is' in the ctrl-function (arg = 0)
+             * Otherwise we have to decrease it in the implementation (arg = 1).
+             */
+            memcpy(seq, ptr, 8);
+            decrement_arg = arg;
+            if(!decrement_sequence(seq, decrement_arg)) {
+                GOSTerr(GOST_F_MAGMA_CIPHER_CTL, GOST_R_CTRL_CALL_FAILED);
+                return -1;
+            }
+
+            if (gost_tlstree(NID_magma_cbc,
+                            (const unsigned char *)c->master_key, newkey,
+                            (const unsigned char *)seq, TLSTREE_MODE_NONE)
+                  > 0) {
+                memset(adjusted_iv, 0, 8);
+                memcpy(adjusted_iv, EVP_CIPHER_CTX_original_iv(ctx), 4);
+                for (j = 3, carry = 0; j >= 0; j--)
+                {
+                    int adj_byte = adjusted_iv[j] + seq[j+4] + carry;
+                    carry = (adj_byte > 255) ? 1 : 0;
+                    adjusted_iv[j] = adj_byte & 0xFF;
+                }
+                EVP_CIPHER_CTX_set_num(ctx, 0);
+                memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), adjusted_iv, 8);
+
+                magma_key(c, newkey);
+                return 1;
+          }
+        }
+        return -1;
     default:
         GOSTerr(GOST_F_MAGMA_CIPHER_CTL, GOST_R_UNSUPPORTED_CIPHER_CTL_COMMAND);
         return -1;

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -1128,18 +1128,16 @@ static int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, v
             c->section_size = arg;
             break;
         }
-#ifdef EVP_CTRL_TLS1_2_TLSTREE
-    case EVP_CTRL_TLS1_2_TLSTREE:
+    case EVP_CTRL_TLSTREE:
         {
           unsigned char newkey[32];
           int mode = EVP_CIPHER_CTX_mode(ctx);
-          static const unsigned char zeroseq[8];
           gost_grasshopper_cipher_ctx_ctr *ctr_ctx = NULL;
           gost_grasshopper_cipher_ctx *c = NULL;
 
           unsigned char adjusted_iv[16];
           unsigned char seq[8];
-          int j, carry;
+          int j, carry, decrement_arg;
           if (mode != EVP_CIPH_CTR_MODE)
             return -1;
 
@@ -1147,22 +1145,21 @@ static int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, v
             EVP_CIPHER_CTX_get_cipher_data(ctx);
           c = &(ctr_ctx->c);
 
+          /*
+           * 'arg' parameter indicates what we should do with sequence value.
+           * 
+           * When function called, seq is incremented after MAC calculation.
+           * In ETM mode, we use seq 'as is' in the ctrl-function (arg = 0)
+           * Otherwise we have to decrease it in the implementation (arg = 1).
+           */
           memcpy(seq, ptr, 8);
-          if (EVP_CIPHER_CTX_encrypting(ctx)) {
-            /*
-             * OpenSSL increments seq after mac calculation.
-             * As we have Mac-Then-Encrypt, we need decrement it here on encryption
-             * to derive the key correctly.
-             * */
-            if (memcmp(seq, zeroseq, 8) != 0)
-            {
-              for(j=7; j>=0; j--)
-              {
-                if (seq[j] != 0) {seq[j]--; break;}
-                else seq[j]  = 0xFF;
-              }
-            }
+          decrement_arg = arg;
+          if (!decrement_sequence(seq, decrement_arg))
+          {
+              GOSTerr(GOST_F_GOST_GRASSHOPPER_CIPHER_CTL, GOST_R_CTRL_CALL_FAILED);
+              return -1;
           }
+
           if (gost_tlstree(NID_grasshopper_cbc, c->master_key.k.b, newkey,
                 (const unsigned char *)seq, TLSTREE_MODE_NONE) > 0) {
             memset(adjusted_iv, 0, 16);
@@ -1181,7 +1178,6 @@ static int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, v
           }
         }
         return -1;
-#endif
 #if 0
     case EVP_CTRL_AEAD_GET_TAG:
     case EVP_CTRL_AEAD_SET_TAG:

--- a/gost_lcl.h
+++ b/gost_lcl.h
@@ -311,6 +311,9 @@ int pack_sign_cp(ECDSA_SIG *s, int order, unsigned char *sig, size_t *siglen);
 /* Get private key as BIGNUM from both 34.10-2001 keys*/
 /* Returns pointer into EVP_PKEY structure */
 BIGNUM *gost_get0_priv_key(const EVP_PKEY *pkey);
+/* from gost_crypt.c */
+/* Decrements 8-byte sequence */ 
+int decrement_sequence(unsigned char *seq, int decrement);
 
 /* Struct describing cipher and used for init/deinit.*/
 struct gost_cipher_st {


### PR DESCRIPTION
add case 'EVP_CTRL_TLSTREE' in ctl function for magma and kuznetchik.
add some GOST tests in tlstree test.
remove OpenSSL3.0 dependencies.
modify gost cipher to store master key, used for TLSTREE mode.

remove projects, that depend on OpenSSL3.0.
add options to remove compiler 'const' errors.