### PR TITLE
Add explicit support for NID_id_GostR3410_2001DH (GOST R 34.10-2001 DH)

### DIFF
--- a/gost_ameth.c
+++ b/gost_ameth.c
@@ -43,6 +43,7 @@ static int pkey_bits_gost(const EVP_PKEY *pk)
 
     switch (EVP_PKEY_base_id(pk)) {
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
     case NID_id_GostR3410_2012_256:
         return 256;
     case NID_id_GostR3410_2012_512:
@@ -87,6 +88,7 @@ static ASN1_STRING *encode_gost_algor_params(const EVP_PKEY *key)
 	}
         break;
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
         pkey_param_nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(key_ptr));
         gkp->hash_params = OBJ_nid2obj(NID_id_GostR3411_94_CryptoProParamSet);
         break;
@@ -127,6 +129,7 @@ static int gost_decode_nid_params(EVP_PKEY *pkey, int pkey_nid, int param_nid)
     case NID_id_GostR3410_2012_256:
     case NID_id_GostR3410_2012_512:
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
         if (!key_ptr) {
             key_ptr = EC_KEY_new();
             if (!EVP_PKEY_assign(pkey, pkey_nid, key_ptr)) {
@@ -186,6 +189,7 @@ static int gost_set_priv_key(EVP_PKEY *pkey, BIGNUM *priv)
     case NID_id_GostR3410_2012_512:
     case NID_id_GostR3410_2012_256:
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
         {
             EC_KEY *ec = EVP_PKEY_get0(pkey);
             if (!ec) {
@@ -210,6 +214,7 @@ BIGNUM *gost_get0_priv_key(const EVP_PKEY *pkey)
     case NID_id_GostR3410_2012_512:
     case NID_id_GostR3410_2012_256:
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
         {
             EC_KEY *ec = EVP_PKEY_get0((EVP_PKEY *)pkey);
             if (ec)
@@ -421,6 +426,7 @@ static int pkey_ctrl_gost(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         md_nid = NID_id_GostR3411_2012_256;
         break;
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
     case NID_id_GostR3410_94:
         md_nid = NID_id_GostR3411_94;
         break;
@@ -1059,6 +1065,7 @@ static int pkey_size_gost(const EVP_PKEY *pk)
     switch (EVP_PKEY_base_id(pk)) {
     case NID_id_GostR3410_94:
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
     case NID_id_GostR3410_2012_256:
         return 64;
     case NID_id_GostR3410_2012_512:
@@ -1153,6 +1160,7 @@ int register_ameth_gost(int nid, EVP_PKEY_ASN1_METHOD **ameth,
         return 0;
     switch (nid) {
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
         EVP_PKEY_asn1_set_free(*ameth, pkey_free_gost_ec);
         EVP_PKEY_asn1_set_private(*ameth,
                                   priv_decode_gost, priv_encode_gost,

--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -276,7 +276,7 @@ static int pkey_GOST_ECcp_encrypt(EVP_PKEY_CTX *pctx, unsigned char *out,
     EVP_PKEY *pubk = EVP_PKEY_CTX_get0_pkey(pctx);
     struct gost_pmeth_data *data = EVP_PKEY_CTX_get_data(pctx);
     int pkey_nid = EVP_PKEY_base_id(pubk);
-    ASN1_OBJECT *crypt_params_obj = (pkey_nid == NID_id_GostR3410_2001) ?
+    ASN1_OBJECT *crypt_params_obj = (pkey_nid == NID_id_GostR3410_2001 || pkey_nid == NID_id_GostR3410_2001DH) ?
         OBJ_nid2obj(NID_id_Gost28147_89_CryptoPro_A_ParamSet) :
         OBJ_nid2obj(NID_id_tc26_gost_28147_param_Z);
     const struct gost_cipher_info *param =

--- a/gost_eng.c
+++ b/gost_eng.c
@@ -39,6 +39,7 @@ static int gost_pkey_asn1_meths(ENGINE* e, EVP_PKEY_ASN1_METHOD** ameth,
                                 const int** nids, int nid);
 
 static EVP_PKEY_METHOD* pmeth_GostR3410_2001 = NULL,
+        * pmeth_GostR3410_2001DH = NULL,
         * pmeth_GostR3410_2012_256 = NULL,
         * pmeth_GostR3410_2012_512 = NULL,
         * pmeth_Gost28147_MAC = NULL, * pmeth_Gost28147_MAC_12 = NULL,
@@ -46,6 +47,7 @@ static EVP_PKEY_METHOD* pmeth_GostR3410_2001 = NULL,
         * pmeth_magma_mac_acpkm = NULL,  * pmeth_grasshopper_mac_acpkm = NULL;
 
 static EVP_PKEY_ASN1_METHOD* ameth_GostR3410_2001 = NULL,
+        * ameth_GostR3410_2001DH = NULL,
         * ameth_GostR3410_2012_256 = NULL,
         * ameth_GostR3410_2012_512 = NULL,
         * ameth_Gost28147_MAC = NULL, * ameth_Gost28147_MAC_12 = NULL,
@@ -96,6 +98,13 @@ static struct gost_meth_minfo {
         &ameth_GostR3410_2001,
         "GOST2001",
         "GOST R 34.10-2001",
+    },
+    {
+        NID_id_GostR3410_2001DH,
+        &pmeth_GostR3410_2001DH,
+        &ameth_GostR3410_2001DH,
+        "GOST2001 DH",
+        "GOST R 34.10-2001 DH",
     },
     {
         NID_id_Gost28147_89_MAC,

--- a/gost_pmeth.c
+++ b/gost_pmeth.c
@@ -39,6 +39,7 @@ static int pkey_gost_init(EVP_PKEY_CTX *ctx)
     if (pkey && EVP_PKEY_get0(pkey)) {
         switch (EVP_PKEY_base_id(pkey)) {
         case NID_id_GostR3410_2001:
+        case NID_id_GostR3410_2001DH:
         case NID_id_GostR3410_2012_256:
         case NID_id_GostR3410_2012_512:
             {
@@ -104,6 +105,7 @@ static int pkey_gost_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             switch (EVP_MD_type((const EVP_MD *)p2)) {
             case NID_id_GostR3411_94:
                 if (pkey_nid == NID_id_GostR3410_2001
+                    || pkey_nid == NID_id_GostR3410_2001DH
                     || pkey_nid == NID_id_GostR3410_94) {
                     pctx->md = (EVP_MD *)p2;
                     return 1;
@@ -492,6 +494,7 @@ static int pkey_gost_ec_cp_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
 
     switch (EVP_PKEY_base_id(pkey)) {
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
     case NID_id_GostR3410_2012_256:
         order = 64;
         break;
@@ -1049,6 +1052,7 @@ int register_pmeth_gost(int id, EVP_PKEY_METHOD **pmeth, int flags)
 
     switch (id) {
     case NID_id_GostR3410_2001:
+    case NID_id_GostR3410_2001DH:
         EVP_PKEY_meth_set_ctrl(*pmeth,
                                pkey_gost_ctrl, pkey_gost_ec_ctrl_str_256);
         EVP_PKEY_meth_set_sign(*pmeth, NULL, pkey_gost_ec_cp_sign);


### PR DESCRIPTION
Superseeds https://github.com/gost-engine/engine/pull/297

Этот патч позволяет в Линуксе использовать PKCS#12 контейнеры, созданные с помощью ViPNet CSP под Windows.

Я могу приложить тестовый контейнер, который был создан следующим образом:

Получен тестовый сертификат по инструкции http://testcert.infotecs.ru/help.html
Полученный тестовый сертификат установлен в Windows
Штатными средствами ViPNet в Windows контнейнер с сертификатом экспортированы в PKCS#12 блоб.
Поведение до:
$ openssl pkcs12 -engine gost -info -in test_vipnet.pfx
engine "gost" set.
Enter Import Password:
MAC: GOST R 34.11-94, Iteration 2000
MAC length: 32, salt length: 32
PKCS7 Data
Shrouded Keybag: PBES2, PBKDF2, gost89, Iteration 2000, PRF id-HMACGostR3411-94
Error outputting keys and certificates
139951986788160:error:0609E09C:digital envelope routines:pkey_set_type:unsupported algorithm:crypto/evp/p_lib.c:210:
139951986788160:error:0606F076:digital envelope routines:EVP_PKCS82PKEY:unsupported private key algorithm:crypto/evp/evp_pkey.c:36:TYPE=GOST R 34.10-2001 DH

Поведение после приложения патча:
$ openssl pkcs12 -engine gost -info -noout -in test_vipnet.pfx
engine "gost" set.
Enter Import Password:
MAC: GOST R 34.11-94, Iteration 2000
MAC length: 32, salt length: 32
PKCS7 Data
Shrouded Keybag: PBES2, PBKDF2, gost89, Iteration 2000, PRF id-HMACGostR3411-94
PKCS7 Encrypted data: PBES2, PBKDF2, gost89, Iteration 2000, PRF id-HMACGostR3411-94
Certificate bag
Certificate bag