### PR TITLE
Fix broken initialization vector, make stateless protocols happy

### DIFF
--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -549,7 +549,7 @@ int gost_cipher_do_cfb(EVP_CIPHER_CTX *ctx, unsigned char *out,
         }
     }
 
-    for (; i + 8 < inl; i += 8, in_ptr += 8, out_ptr += 8) {
+    for (; (inl - i) >= 8; i += 8, in_ptr += 8, out_ptr += 8) {
         /*
          * block cipher current iv
          */
@@ -610,7 +610,7 @@ static int gost_cipher_do_cnt(EVP_CIPHER_CTX *ctx, unsigned char *out,
         }
     }
 
-    for (; i + 8 < inl; i += 8, in_ptr += 8, out_ptr += 8) {
+    for (; (inl - i) >= 8; i += 8, in_ptr += 8, out_ptr += 8) {
         /*
          * block cipher current iv
          */


### PR DESCRIPTION
If at the input of the encryption function in the CFB mode we have
an integer number of blocks, then in the main loop all blocks will be
processed, except for the last one due to an incorrect border check.
The last block will be fully processed as a "partial" remainder, but
the initialization vector will not be updated. And, thus, the value
of IV will always be incorrect in this case.

This breaks stateless protocols due to an invalid initialization vector:
all messages except the first cannot be decrypted. (Naturally, we are
talking about a case with disabled key meshing, which does not allow
context recovery due to an erroneous implementation.)

It is worth noting here that the code for processing partial blocks
(both at the input of the encryption functions and at the output) is
a historically unnecessary artifact, since we do not set the
EVP_CIPH_FLAG_CUSTOM_CIPHER flag and, as a result, OpenSSL processes
partial blocks for us.

This patch corrects the checking of the main loop boundary.

A similar error is present in the code for the CNT mode, but there it
does not manifest itself in any way, because the restoration of the
state in this mode is impossible: even after disabling key meshing, we
still have the state-dependent transformation of the IV.

As an extra result of this fix, the code for processing partial blocks
can be completely removed now.