### PR TITLE
Remove 'set -e' in Travis-CI. It can cause weird behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ before_script:
   - cd ..
 
 script:
-  - set -e
   - mkdir build
   - cd build
   - cmake -DOPENSSL_ROOT_DIR=${PREFIX} -DOPENSSL_LIBRARIES=${PREFIX}/lib -DOPENSSL_ENGINES_DIR=${PREFIX}/engines ${ASAN} ..


### PR DESCRIPTION
https://github.com/travis-ci/docs-travis-ci-com/issues/1672

Сейчас не собирается только на macOS, но не исключено, что в дальнейшем вылезит и на других платформах.

Кажется безобидные команды 
`set -e;
mkdir build;
cd build`
но после `cd` падает.

При этом 
`mkdir build;
cd build;
set -e`
работает нормально. Т.е. поведение непредсказуемое.