### PR TITLE
Fix gost engine suffix (for MacOS X)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
             - run: .github/script.sh
 
     gcc-asan-openssl-master:
-        runs-on: ubuntu-20.04
+        strategy:
+            matrix:
+                os: [ ubuntu-20.04, macos-11.0 ]
+        runs-on: ${{matrix.os}}
         env:
             OPENSSL_BRANCH: master
             ASAN: -DASAN=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,26 @@ jobs:
             OPENSSL_BRANCH: master
             ASAN: -DASAN=1
         steps:
-            - uses: actions/checkout@v2
-            - run: .github/before_script.sh
+            - name: install cpanm and Test2::V0
+              uses: perl-actions/install-with-cpanm@v1
+              with:
+                  install: Test2::V0
+            - name: Checkout gost-engine
+              uses: actions/checkout@v2
+            - name: checkout OpenSSL
+              uses: actions/checkout@v2
+              with:
+                  repository: openssl/openssl
+                  ref: master
+                  path: openssl
+            - name: configure OpenSSL
+              run: |
+                  mkdir $HOME/opt
+                  ./Configure --prefix=$HOME/opt
+              working-directory: openssl
+            - name: build+install OpenSSL
+              run: make -s install_sw
+              working-directory: openssl
             - run: .github/script.sh
 
     gcc-openssl-stable-x86:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,17 @@ jobs:
             - run: .github/script.sh
 
     gcc-asan-openssl-master:
-        strategy:
-            matrix:
-                os: [ ubuntu-20.04, macos-11.0 ]
-        runs-on: ${{matrix.os}}
+        runs-on: ubuntu-20.04
+        env:
+            OPENSSL_BRANCH: master
+            ASAN: -DASAN=1
+        steps:
+            - uses: actions/checkout@v2
+            - run: .github/before_script.sh
+            - run: .github/script.sh
+
+    macos-asan-openssl-master:
+        runs-on: macos-11.0
         env:
             OPENSSL_BRANCH: master
             ASAN: -DASAN=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             - run: .github/script.sh
 
     macos-asan-openssl-master:
-        runs-on: macos-11.0
+        runs-on: macos-latest
         env:
             OPENSSL_BRANCH: master
             ASAN: -DASAN=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,10 @@ add_library(gost_core STATIC ${GOST_LIB_SOURCE_FILES})
 set_target_properties(gost_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(gost_engine MODULE ${GOST_ENGINE_SOURCE_FILES})
-set_target_properties(gost_engine PROPERTIES PREFIX "" OUTPUT_NAME "gost")
+# Set the suffix explicitly to adapt to OpenSSL's idea of what a
+# module suffix should be
+set_target_properties(gost_engine PROPERTIES
+  PREFIX "" OUTPUT_NAME "gost" SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
 target_link_libraries(gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 
 set(GOST_SUM_SOURCE_FILES


### PR DESCRIPTION
On MacOS X, OpenSSL and cmake have different ideas on what suffix a
dynamically loadable module should have.  OpenSSL expects .dylib,
while cmake uses .so by default.

Fixed by explicitly telling cmake to use the same suffix as for shared
libraries.