### PR TITLE
Always cNORM before "\n"

### DIFF
--- a/test_ciphers.c
+++ b/test_ciphers.c
@@ -28,9 +28,9 @@
 #define cDBLUE	"\033[0;34m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "Test FAILED\n" cNORM); \
+		 printf(cRED "Test FAILED" cNORM "\n"); \
 	     else \
-		 printf(cGREEN "Test passed\n" cNORM);}
+		 printf(cGREEN "Test passed" cNORM "\n");}
 
 /* Pragma to allow commenting out some tests. */
 #pragma GCC diagnostic ignored "-Wunused-const-variable"
@@ -478,7 +478,7 @@ int main(int argc, char **argv)
 	const EVP_CIPHER *type = EVP_get_cipherbynid(t->nid);
 	const char *name = EVP_CIPHER_name(type);
 
-	printf(cBLUE "# Tests for %s [%s]\n" cNORM, name, standard);
+	printf(cBLUE "# Tests for %s [%s]" cNORM "\n", name, standard);
 	for (inplace = 0; inplace <= 1; inplace++)
 	    ret |= test_block(type, name, t->block,
 		t->plaintext, t->key, t->expected, t->size,
@@ -499,15 +499,15 @@ int main(int argc, char **argv)
 	    if (t->nid == nids[k])
 		break;
 	if (!t->nid)
-	    printf(cMAGENT "Cipher %s is untested!\n" cNORM, OBJ_nid2sn(nids[k]));
+	    printf(cMAGENT "Cipher %s is untested!" cNORM "\n", OBJ_nid2sn(nids[k]));
     }
 
     ENGINE_finish(eng);
     ENGINE_free(eng);
 
     if (ret)
-	printf(cDRED "= Some tests FAILED!\n" cNORM);
+	printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-	printf(cDGREEN "= All tests passed!\n" cNORM);
+	printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }

--- a/test_context.c
+++ b/test_context.c
@@ -28,9 +28,9 @@
 #define cDBLUE	"\033[0;34m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
+		 printf(cRED "  Test FAILED" cNORM "\n"); \
 	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
+		 printf(cGREEN "  Test passed" cNORM "\n");}
 
 static void hexdump(const void *ptr, size_t len)
 {
@@ -61,7 +61,7 @@ static int test_contexts_cipher(int nid, const int enc, int acpkm)
     const EVP_CIPHER *type = EVP_get_cipherbynid(nid);
     const char *name = EVP_CIPHER_name(type);
 
-    printf(cBLUE "%s test for %s (nid %d)\n" cNORM,
+    printf(cBLUE "%s test for %s (nid %d)" cNORM "\n",
 	enc ? "Encryption" : "Decryption", name, nid);
 
     /* produce base encryption */
@@ -137,7 +137,7 @@ static int test_contexts_digest(int nid, int mac)
     const EVP_MD *type = EVP_get_digestbynid(nid);
     const char *name = EVP_MD_name(type);
 
-    printf(cBLUE "Digest test for %s (nid %d)\n" cNORM, name, nid);
+    printf(cBLUE "Digest test for %s (nid %d)" cNORM "\n", name, nid);
 
     /* produce base digest */
     EVP_MD_CTX *ctx, *save;
@@ -267,8 +267,8 @@ int main(int argc, char **argv)
     ENGINE_free(eng);
 
     if (ret)
-	printf(cDRED "= Some tests FAILED!\n" cNORM);
+	printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-	printf(cDGREEN "= All tests passed!\n" cNORM);
+	printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }

--- a/test_curves.c
+++ b/test_curves.c
@@ -32,9 +32,9 @@
 #define TEST_ASSERT(e) { \
 	test = e; \
 	if (test) \
-		printf(cRED "  Test FAILED\n" cNORM); \
+		printf(cRED "  Test FAILED" cNORM "\n"); \
 	else \
-		printf(cGREEN "  Test passed\n" cNORM); \
+		printf(cGREEN "  Test passed" cNORM "\n"); \
 }
 
 struct test_curve {
@@ -93,7 +93,7 @@ static int parameter_test(struct test_curve *tc)
     printf("\n");
 
     if (!OBJ_nid2obj(nid)) {
-	printf(cRED "NID %d not found\n" cNORM, nid);
+	printf(cRED "NID %d not found" cNORM "\n", nid);
 	return 1;
     }
 
@@ -109,7 +109,7 @@ static int parameter_test(struct test_curve *tc)
     EC_KEY *ec;
     T(ec = EC_KEY_new());
     if (!fill_GOST_EC_params(ec, nid)) {
-	printf(cRED "fill_GOST_EC_params FAIL\n" cNORM);
+	printf(cRED "fill_GOST_EC_params FAIL" cNORM "\n");
 	ERR_print_errors_fp(stderr);
 	return 1;
     }
@@ -242,8 +242,8 @@ int main(int argc, char **argv)
     ENGINE_free(eng);
 
     if (ret)
-	printf(cDRED "= Some tests FAILED!\n" cNORM);
+	printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-	printf(cDGREEN "= All tests passed!\n" cNORM);
+	printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }

--- a/test_derive.c
+++ b/test_derive.c
@@ -31,9 +31,9 @@
 #define cCYAN   "\033[1;36m"
 #define cNORM   "\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
-                 printf(cRED "  Test FAILED\n" cNORM); \
+                 printf(cRED "  Test FAILED" cNORM "\n"); \
              else \
-                 printf(cGREEN "  Test passed\n" cNORM);}
+                 printf(cGREEN "  Test passed" cNORM "\n");}
 
 #ifndef OSSL_NELEM
 # define OSSL_NELEM(x) (sizeof(x)/sizeof((x)[0]))
@@ -185,7 +185,7 @@ static EVP_PKEY *load_private_key(int key_nid, int param_nid, const char *pk,
             printf("Public key %08x matches private key %08x\n",
                    *(int *)pub, *(int *)pk);
         else {
-            printf(cRED "Public key mismatch!\n" cNORM);
+            printf(cRED "Public key mismatch!" cNORM "\n");
             exit(1);
         }
         EC_POINT_free(xy);
@@ -393,9 +393,9 @@ int main(int argc, char **argv)
     ENGINE_free(eng);
 
     if (ret)
-        printf(cDRED "= Some tests FAILED!\n" cNORM);
+        printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-        printf(cDGREEN "= All tests passed!\n" cNORM);
+        printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }
 /* vim: set expandtab cinoptions=\:0,l1,t0,g0,(0 sw=4 : */

--- a/test_digest.c
+++ b/test_digest.c
@@ -49,9 +49,9 @@
 #define cMAGENT "\033[1;35m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
+		 printf(cRED "  Test FAILED" cNORM "\n"); \
 	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
+		 printf(cGREEN "  Test passed" cNORM "\n");}
 
 /* To test older APIs. */
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -509,7 +509,7 @@ static int do_hmac_old(int iter, const EVP_MD *type, const char *plaintext,
     if (t->mdsize)
 	T(len == t->mdsize);
     if (memcmp(md, t->hmac, len) != 0) {
-	printf(cRED "hmac mismatch\n" cNORM);
+	printf(cRED "hmac mismatch" cNORM "\n");
 	hexdump(t->hmac, len);
 	hexdump(md, len);
 	return 1;
@@ -547,7 +547,7 @@ static int do_hmac_prov(int iter, const EVP_MD *type, const char *plaintext,
     if (t->mdsize)
 	T(len == t->mdsize);
     if (memcmp(md, t->hmac, len) != 0) {
-	printf(cRED "hmac mismatch\n" cNORM);
+	printf(cRED "hmac mismatch" cNORM "\n");
 	hexdump(t->hmac, len);
 	hexdump(md, len);
 	return 1;
@@ -623,7 +623,7 @@ static int do_cmac_prov(int iter, const char *plaintext,
      * So, just compare until what we need. */
     T(mdsize <= len);
     if (memcmp(md, t->digest, mdsize) != 0) {
-	printf(cRED "cmac mismatch\n" cNORM);
+	printf(cRED "cmac mismatch" cNORM "\n");
 	hexdump(t->digest, mdsize);
 	hexdump(md, len);
 	return 1;
@@ -673,7 +673,7 @@ static int do_digest(int iter, const EVP_MD *type, const char *plaintext,
     EVP_MD_CTX_free(ctx);
     T(len == mdsize);
     if (memcmp(md, t->digest, mdsize) != 0) {
-	printf(cRED "digest mismatch\n" cNORM);
+	printf(cRED "digest mismatch" cNORM "\n");
 	hexdump(t->digest, mdsize);
 	hexdump(md, mdsize);
 	return 1;
@@ -711,9 +711,9 @@ static int do_test(const struct hash_testvec *tv)
     OPENSSL_free(buf);
 
     if (!ret)
-	printf(cGREEN "success\n" cNORM);
+	printf(cGREEN "success" cNORM "\n");
     else
-	printf(cRED "fail\n" cNORM);
+	printf(cRED "fail" cNORM "\n");
     return ret;
 }
 
@@ -775,13 +775,13 @@ static int do_synthetic_once(const struct hash_testvec *tv, unsigned int shifts)
     EVP_MD_CTX_free(ctx2);
 
     if (len != mdlen) {
-	printf(cRED "digest output len mismatch %u != %u (expected)\n" cNORM,
+	printf(cRED "digest output len mismatch %u != %u (expected)" cNORM "\n",
 	    len, mdlen);
 	goto err;
     }
 
     if (memcmp(md, tv->digest, mdlen) != 0) {
-	printf(cRED "digest mismatch\n" cNORM);
+	printf(cRED "digest mismatch" cNORM "\n");
 
 	unsigned int i;
 	printf("  Expected value is: ");
@@ -811,9 +811,9 @@ static int do_synthetic_test(const struct hash_testvec *tv)
 	ret |= do_synthetic_once(tv, shifts);
 
     if (!ret)
-	printf(cGREEN "success\n" cNORM);
+	printf(cGREEN "success" cNORM "\n");
     else
-	printf(cRED "fail\n" cNORM);
+	printf(cRED "fail" cNORM "\n");
     return 0;
 }
 
@@ -851,15 +851,15 @@ int main(int argc, char **argv)
 	    if (tv->nid == nids[k])
 		break;
 	if (!tv->nid)
-	    printf(cMAGENT "Digest %s is untested!\n" cNORM, OBJ_nid2sn(nids[k]));
+	    printf(cMAGENT "Digest %s is untested!" cNORM "\n", OBJ_nid2sn(nids[k]));
     }
 
     ENGINE_finish(eng);
     ENGINE_free(eng);
 
     if (ret)
-	printf(cDRED "= Some tests FAILED!\n" cNORM);
+	printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-	printf(cDGREEN "= All tests passed!\n" cNORM);
+	printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }

--- a/test_params.c
+++ b/test_params.c
@@ -39,9 +39,9 @@
 #define cDBLUE	"\033[0;34m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
+		 printf(cRED "  Test FAILED" cNORM "\n"); \
 	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
+		 printf(cGREEN "  Test passed" cNORM "\n");}
 
 struct test_param {
     unsigned int param;		/* NID of EC parameters */
@@ -873,9 +873,9 @@ static void hexdump(const void *ptr, size_t len)
 static void print_test_result(int err)
 {
     if (err == 1)
-	printf(cGREEN "correct\n" cNORM);
+	printf(cGREEN "correct" cNORM "\n");
     else if (err == 0)
-	printf(cRED "incorrect\n" cNORM);
+	printf(cRED "incorrect" cNORM "\n");
     else
 	ERR_print_errors_fp(stderr);
 }
@@ -1050,7 +1050,7 @@ static int test_param(struct test_param *t)
     int hash_nid = 0;
     const char *sn = OBJ_nid2sn(t->param);
 
-    printf(cBLUE "Test %s (cp):\n" cNORM, sn);
+    printf(cBLUE "Test %s (cp):" cNORM "\n", sn);
 
     switch (t->len) {
 	case 256 / 8:
@@ -1180,8 +1180,8 @@ int main(int argc, char **argv)
     ENGINE_free(eng);
 
     if (ret)
-	printf(cDRED "= Some tests FAILED!\n" cNORM);
+	printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-	printf(cDGREEN "= All tests passed!\n" cNORM);
+	printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }

--- a/test_sign.c
+++ b/test_sign.c
@@ -41,9 +41,9 @@
 #define cCYAN	"\033[1;36m"
 #define cNORM	"\033[m"
 #define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
+		 printf(cRED "  Test FAILED" cNORM "\n"); \
 	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
+		 printf(cGREEN "  Test passed" cNORM "\n");}
 
 struct test_sign {
     const char *name;
@@ -83,17 +83,17 @@ static void hexdump(const void *ptr, size_t len)
 static void print_test_tf(int err, int val, const char *t, const char *f)
 {
     if (err == 1)
-	printf(cGREEN "%s\n" cNORM, t);
+	printf(cGREEN "%s" cNORM "\n", t);
     else
-	printf(cRED "%s [%d]\n" cNORM, f, val);
+	printf(cRED "%s [%d]" cNORM "\n", f, val);
 }
 
 static void print_test_result(int err)
 {
     if (err == 1)
-	printf(cGREEN "success\n" cNORM);
+	printf(cGREEN "success" cNORM "\n");
     else if (err == 0)
-	printf(cRED "failure\n" cNORM);
+	printf(cRED "failure" cNORM "\n");
     else
 	ERR_print_errors_fp(stderr);
 }
@@ -103,7 +103,7 @@ static int test_sign(struct test_sign *t)
     int ret = 0, err;
     size_t len = t->bits / 8;
 
-    printf(cBLUE "Test %s:\n" cNORM, t->name);
+    printf(cBLUE "Test %s:" cNORM "\n", t->name);
 
     /* Signature type from size. */
     int type = 0;
@@ -197,7 +197,7 @@ static int test_sign(struct test_sign *t)
 	ret |= err;
 	EVP_PKEY_free(pkey);
     } else
-	printf(cCYAN "skipped\n" cNORM);
+	printf(cCYAN "skipped" cNORM "\n");
     BIO_free(bp);
 
     /* Convert to DER and back, using memory API. */
@@ -334,8 +334,8 @@ int main(int argc, char **argv)
     ENGINE_free(eng);
 
     if (ret)
-	printf(cDRED "= Some tests FAILED!\n" cNORM);
+	printf(cDRED "= Some tests FAILED!" cNORM "\n");
     else
-	printf(cDGREEN "= All tests passed!\n" cNORM);
+	printf(cDGREEN "= All tests passed!" cNORM "\n");
     return ret;
 }


### PR DESCRIPTION
Using cNORM after "\n" may or may not work, probably because of the
line buffered nature of standard output.

If an error is displayed immediately after a printf that has cNORM
after "\n", the error output sometimes "overrides" the cNORM, and you
may end up with a surprisingly colorful error message, not to mention
that this may also affect your prompt in the same manner.

The lesson is to always output cNORM before the ending "\n".