### PR TITLE
Don't put test results or intermediary files in the source tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,12 @@ add_custom_target(tags
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_custom_target(tcl_tests
-    COMMAND ENGINE_DIR=${OUTPUT_DIRECTORY} sh ./runtest.sh
+    COMMAND OPENSSL_LIBCRYPTO=${OPENSSL_CRYPTO_LIBRARY}
+            OPENSSL_APP=${OPENSSL_PROGRAM}
+            TESTSRC=${CMAKE_SOURCE_DIR}/tcl_tests
+            TESTDIR=${CMAKE_BINARY_DIR}/tcl_tests
+            ENGINE_DIR=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            sh ./runtest.sh
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tcl_tests)
 
 add_executable(test_tlstree test_tlstree.c)

--- a/tcl_tests/dgst.try
+++ b/tcl_tests/dgst.try
@@ -25,7 +25,7 @@ test -createsfiles {dgst.dat dgst0.dat dgst2.dat dgst8.dat dgst63.dat dgst_CF.da
 	makeFile dgst.dat [string repeat "Test data to digest.\n" 100] binary
 	makeFile dgst0.dat "" binary
 	makeFile dgst63.dat "012345678901234567890123456789012345678901234567890123456789012" binary
-	file copy -force ../dgst_CF.dat ../dgst_ex1.dat ../dgst_ex2.dat .
+	file copy -force $::test::src/dgst_CF.dat $::test::src/dgst_ex1.dat $::test::src/dgst_ex2.dat .
 } 0 ""
 
 test "Вычисление дайджеста алгоритмом md_gost12_256" {

--- a/tcl_tests/enc.try
+++ b/tcl_tests/enc.try
@@ -2,13 +2,13 @@
 lappend auto_path [file dirname [info script]] 
 package require ossltest
 set plain0 [getFile plain.enc]
-file copy -force cfb0.enc $::test::dir
-file copy -force cnt0.enc $::test::dir
-file copy -force cbc0.enc $::test::dir
-file copy -force aes0.enc $::test::dir
-file copy -force plain.enc $::test::dir
-file copy -force magma_plain.enc $::test::dir
-file copy -force magma_acpkm_plain.enc $::test::dir
+file copy -force $::test::src/cfb0.enc $::test::dir
+file copy -force $::test::src/cnt0.enc $::test::dir
+file copy -force $::test::src/cbc0.enc $::test::dir
+file copy -force $::test::src/aes0.enc $::test::dir
+file copy -force $::test::src/plain.enc $::test::dir
+file copy -force $::test::src/magma_plain.enc $::test::dir
+file copy -force $::test::src/magma_acpkm_plain.enc $::test::dir
 set cfb1 [getFile cfb1.enc]
 set cbc1 [getFile cbc1.enc]
 set cnt1 [getFile cnt1.enc]

--- a/tcl_tests/mac.try
+++ b/tcl_tests/mac.try
@@ -10,7 +10,7 @@ test -createsfiles {dgst.dat dgst0.dat dgst2.dat dgst8.dat dgst63.dat mac-grassh
 	makeFile dgst2.dat [string repeat "1\n" 1] binary
 	makeFile dgst8.dat [string repeat "1\n" 4] binary
 	makeFile dgst63.dat "012345678901234567890123456789012345678901234567890123456789012" binary
-	file copy -force ../mac-grasshopper.dat ../mac-magma.dat .
+	file copy -force $::test::src/mac-grasshopper.dat $::test::src/mac-magma.dat .
 } 0 ""
 
 test "Вычисление HMAC(md_gost12_512)" {

--- a/tcl_tests/ossltest.tcl
+++ b/tcl_tests/ossltest.tcl
@@ -62,6 +62,16 @@ set test::suffix ""
 package require base64
 
 #
+# set  up test::src variable
+#
+
+if {[info exists env(TESTSRC)]} {
+	set ::test::src [file normalize $env(TESTSRC)]
+} else {
+	set ::test::src [pwd]
+}	
+
+#
 # set  up test::dir variable
 #
 

--- a/tcl_tests/runtest.sh
+++ b/tcl_tests/runtest.sh
@@ -23,6 +23,15 @@
 
 CRYPTOPACK_MAIN_VERSION=3
 
+if [ -n "$OPENSSL_LIBCRYPTO" ]; then
+    libdir=`dirname $OPENSSL_LIBCRYPTO`
+    # Linux, ELF HP-UX
+    LD_LIBRARY_PATH=${libdir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    export LD_LIBRARY_PATH
+    # MacOS X
+    DYLD_LIBRARY_PATH=${libdir}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
+    export DYLD_LIBRARY_PATH
+fi
 : ${OPENSSL_APP:=$(which openssl 2>/dev/null)}
 if [ -z "$OPENSSL_APP" ]; then
 	if [ "$OS" != "Windows NT" -a "$OS" != "Windows_NT" ]; then
@@ -79,10 +88,11 @@ APP_SUFFIX=`basename $OPENSSL_APP .exe|sed s/openssl//`
 [ -n "$OPENSSL_APP" ]&& export OPENSSL_APP
 ENGINE_NAME=`$TCLSH getengine.tcl`
 export ENGINE_NAME
-TESTDIR=`hostname`-$ENGINE_NAME
+[ -z "$TESTDIR" ] && TESTDIR=`pwd`
+TESTDIR=${TESTDIR}/`hostname`-$ENGINE_NAME
 [ -n "$APP_SUFFIX" ] && TESTDIR=${TESTDIR}-${APP_SUFFIX}
 [ -d ${TESTDIR} ] && rm -rf ${TESTDIR}
-mkdir ${TESTDIR}
+mkdir -p ${TESTDIR}
 cp oidfile ${TESTDIR}
 export TESTDIR
 


### PR DESCRIPTION
When building in a directory that's separate from the source
directory, test results should end up in the build directory, not the
source directory.

Essentially, unless you do build in the source directory, it should be
regarded as read-only when building.