### PR TITLE
Install manuals in the correct location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ target_link_libraries(test_tlstree PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
 # install programs and manuals
 install(TARGETS gostsum gost12sum RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES gostsum.1 gost12sum.1 DESTINATION ${CMAKE_INSTALL_DIR}/man1)
+install(FILES gostsum.1 gost12sum.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 # install engine in library and module form
 install(TARGETS lib_gost_engine EXPORT GostEngineConfig LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Cmake doesn't support the variable CMAKE_INSTALL_DIR.  However, with
the GNUInstallDirs module, there is the variable CMAKE_INSTALL_MANDIR.