### PR TITLE
.github/workflows/codeql-analysis.yml: Bump the OpenSSL version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 name: "CodeQL"
 
 env:
-  OPENSSL_BRANCH: openssl-3.0.0-alpha6
+  OPENSSL_BRANCH: openssl-3.0.0-alpha13
   #RPATH: "-Wl,-rpath=${PREFIX}/lib"
   #PREFIX: ${HOME}/opt
   #PATH: ${PREFIX}/bin:${PATH}


### PR DESCRIPTION
From 3.0.0-alpha6 to 3.0.0-alpha13, mostly for Analysis to avoid
getting failures when compiling, considering that the GOST source has
adapted for the latter version.