### PR TITLE
Make test programs less hard-coded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,10 +201,10 @@ target_link_libraries(test_ciphers ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME ciphers COMMAND test_ciphers)
 set_tests_properties(ciphers PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
+# test_curves is an internals testing program, it doesn't need a test env
 add_executable(test_curves test_curves.c)
 target_link_libraries(test_curves gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME curves
-	COMMAND test_curves)
+add_test(NAME curves COMMAND test_curves)
 
 add_executable(test_params test_params.c)
 target_link_libraries(test_params ${OPENSSL_CRYPTO_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,16 +231,16 @@ target_link_libraries(test_context ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME context COMMAND test_context)
 set_tests_properties(context PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
+# test_keyexpimp is an internals testing program, it doesn't need a test env
 add_executable(test_keyexpimp test_keyexpimp.c)
 #target_compile_definitions(test_keyexpimp PUBLIC -DOPENSSL_LOAD_CONF)
 target_link_libraries(test_keyexpimp gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME keyexpimp
-	COMMAND test_keyexpimp)
+add_test(NAME keyexpimp COMMAND test_keyexpimp)
 
+# test_gost89 is an internals testing program, it doesn't need a test env
 add_executable(test_gost89 test_gost89.c)
 target_link_libraries(test_gost89 gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME gost89
-	COMMAND test_gost89)
+add_test(NAME gost89 COMMAND test_gost89)
 
 if(NOT SKIP_PERL_TESTS)
     execute_process(COMMAND perl -MTest2::V0 -e ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,15 +183,23 @@ set(GOST_ENGINE_SOURCE_FILES
         gost_eng.c
         )
 
+set(TEST_ENVIRONMENT
+        CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        PERL5LIB=${CMAKE_CURRENT_SOURCE_DIR}/test
+        OPENSSL_ENGINES=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        OPENSSL_PROGRAM=${OPENSSL_PROGRAM}
+        OPENSSL_CRYPTO_LIBRARY=${OPENSSL_CRYPTO_LIBRARY}
+        OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/test/engine.cnf
+        )
 add_executable(test_digest test_digest.c)
-target_link_libraries(test_digest gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME digest
-	COMMAND test_digest)
+target_link_libraries(test_digest ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME digest COMMAND test_digest)
+set_tests_properties(digest PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_ciphers test_ciphers.c)
-target_link_libraries(test_ciphers gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME ciphers
-	COMMAND test_ciphers)
+target_link_libraries(test_ciphers ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME ciphers COMMAND test_ciphers)
+set_tests_properties(ciphers PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_curves test_curves.c)
 target_link_libraries(test_curves gost_core ${OPENSSL_CRYPTO_LIBRARY})
@@ -199,29 +207,29 @@ add_test(NAME curves
 	COMMAND test_curves)
 
 add_executable(test_params test_params.c)
-target_link_libraries(test_params gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME parameters
-	COMMAND test_params)
+target_link_libraries(test_params ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME parameters COMMAND test_params)
+set_tests_properties(parameters PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_derive test_derive.c)
-target_link_libraries(test_derive gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME derive
-	COMMAND test_derive)
+target_link_libraries(test_derive ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME derive COMMAND test_derive)
+set_tests_properties(derive PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_sign test_sign.c)
-target_link_libraries(test_sign gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME sign/verify
-	COMMAND test_sign)
+target_link_libraries(test_sign ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME sign/verify COMMAND test_sign)
+set_tests_properties(sign/verify PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_tls test_tls.c)
-target_link_libraries(test_tls gost_core ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-add_test(NAME TLS
-	COMMAND test_tls)
+target_link_libraries(test_tls ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+add_test(NAME TLS COMMAND test_tls)
+set_tests_properties(TLS PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_context test_context.c)
-target_link_libraries(test_context gost_core ${OPENSSL_CRYPTO_LIBRARY})
-add_test(NAME context
-	COMMAND test_context)
+target_link_libraries(test_context ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME context COMMAND test_context)
+set_tests_properties(context PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_keyexpimp test_keyexpimp.c)
 #target_compile_definitions(test_keyexpimp PUBLIC -DOPENSSL_LOAD_CONF)
@@ -238,14 +246,6 @@ if(NOT SKIP_PERL_TESTS)
     execute_process(COMMAND perl -MTest2::V0 -e ""
 	ERROR_QUIET RESULT_VARIABLE HAVE_TEST2_V0)
     if(NOT HAVE_TEST2_V0)
-        set(TEST_ENVIRONMENT
-          CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-          PERL5LIB=${CMAKE_CURRENT_SOURCE_DIR}/test
-          OPENSSL_ENGINES=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-          OPENSSL_PROGRAM=${OPENSSL_PROGRAM}
-          OPENSSL_CRYPTO_LIBRARY=${OPENSSL_CRYPTO_LIBRARY}
-          OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/test/empty.cnf
-          )
 	add_test(NAME engine
 	    COMMAND prove --merge -PWrapOpenSSL ${CMAKE_CURRENT_SOURCE_DIR}/test)
 	set_tests_properties(engine PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")

--- a/test/engine.cnf
+++ b/test/engine.cnf
@@ -1,0 +1,7 @@
+openssl_conf = openssl_def
+[openssl_def]
+engines = engines
+[engines]
+gost = gost_conf
+[gost_conf]
+default_algorithms = ALL

--- a/test_ciphers.c
+++ b/test_ciphers.c
@@ -463,13 +463,7 @@ int main(int argc, char **argv)
     /* Trigger SIGBUS for unaligned access. */
     sysmips(MIPS_FIXADE, 0);
 #endif
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     for (t = testcases; t->nid; t++) {
 	int inplace;
@@ -489,7 +483,9 @@ int main(int argc, char **argv)
 		t->iv, t->iv_size, t->acpkm);
     }
 
+    ENGINE *eng;
     ENGINE_CIPHERS_PTR fn_c;
+    T(eng = ENGINE_by_id("gost"));
     T(fn_c = ENGINE_get_ciphers(eng));
     const int *nids;
     int n, k;
@@ -501,8 +497,6 @@ int main(int argc, char **argv)
 	if (!t->nid)
 	    printf(cMAGENT "Cipher %s is untested!" cNORM "\n", OBJ_nid2sn(nids[k]));
     }
-
-    ENGINE_finish(eng);
     ENGINE_free(eng);
 
     if (ret)

--- a/test_context.c
+++ b/test_context.c
@@ -245,13 +245,7 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     const struct testcase_cipher *tc;
     for (tc = testcases_ciphers; tc->nid; tc++) {
@@ -262,9 +256,6 @@ int main(int argc, char **argv)
     for (td = testcases_digests; td->nid; td++) {
 	ret |= test_contexts_digest(td->nid, td->mac);
     }
-
-    ENGINE_finish(eng);
-    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!" cNORM "\n");

--- a/test_curves.c
+++ b/test_curves.c
@@ -5,7 +5,6 @@
  * See https://www.openssl.org/source/license.html for details
  */
 
-#include "e_gost_err.h"
 #include "gost_lcl.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
@@ -225,21 +224,10 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
-    OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
-
     struct test_curve *tc;
     for (tc = test_curves; tc->nid; tc++) {
 	ret |= parameter_test(tc);
     }
-
-    ENGINE_finish(eng);
-    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!" cNORM "\n");

--- a/test_derive.c
+++ b/test_derive.c
@@ -364,13 +364,7 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     int i;
     for (i = 0; i < OSSL_NELEM(derive_tests); i++)
@@ -388,9 +382,6 @@ int main(int argc, char **argv)
         ret |= test_derive_alg("gost2012_512", "B", i);
         ret |= test_derive_alg("gost2012_512", "C", i);
     }
-
-    ENGINE_finish(eng);
-    ENGINE_free(eng);
 
     if (ret)
         printf(cDRED "= Some tests FAILED!" cNORM "\n");

--- a/test_digest.c
+++ b/test_digest.c
@@ -821,13 +821,7 @@ int main(int argc, char **argv)
     /* Trigger SIGBUS for unaligned access. */
     sysmips(MIPS_FIXADE, 0);
 #endif
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     const struct hash_testvec *tv;
     for (tv = testvecs; tv->nid; tv++) {
@@ -837,7 +831,9 @@ int main(int argc, char **argv)
 	    ret |= do_synthetic_test(tv);
     }
 
+    ENGINE *eng;
     ENGINE_DIGESTS_PTR fn_c;
+    T(eng = ENGINE_by_id("gost"));
     T(fn_c = ENGINE_get_digests(eng));
     const int *nids;
     int n, k;
@@ -849,8 +845,6 @@ int main(int argc, char **argv)
 	if (!tv->nid)
 	    printf(cMAGENT "Digest %s is untested!" cNORM "\n", OBJ_nid2sn(nids[k]));
     }
-
-    ENGINE_finish(eng);
     ENGINE_free(eng);
 
     if (ret)

--- a/test_params.c
+++ b/test_params.c
@@ -1160,13 +1160,7 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     struct test_param **tpp;
     for (tpp = test_params; *tpp; tpp++)
@@ -1175,9 +1169,6 @@ int main(int argc, char **argv)
     struct test_cert *tc;
     for (tc = test_certs; tc->cert; tc++)
 	ret |= test_cert(tc);
-
-    ENGINE_finish(eng);
-    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!" cNORM "\n");

--- a/test_sign.c
+++ b/test_sign.c
@@ -7,7 +7,6 @@
  * See https://www.openssl.org/source/license.html for details
  */
 
-#include "e_gost_err.h"
 #include "gost_lcl.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
@@ -17,6 +16,7 @@
 #include <openssl/ec.h>
 #include <openssl/bn.h>
 #include <openssl/store.h>
+#include <openssl/engine.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -318,20 +318,11 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     struct test_sign *sp;
     for (sp = test_signs; sp->name; sp++)
 	ret |= test_sign(sp);
-
-    ENGINE_finish(eng);
-    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!" cNORM "\n");

--- a/test_tls.c
+++ b/test_tls.c
@@ -355,13 +355,7 @@ int main(int argc, char **argv)
 {
     int ret = 0;
 
-    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
-    ERR_load_crypto_strings();
-    ENGINE *eng;
-    T(eng = ENGINE_by_id("gost"));
-    T(ENGINE_init(eng));
-    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
 
     char *p;
     if ((p = getenv("VERBOSE")))
@@ -376,9 +370,6 @@ int main(int argc, char **argv)
     ret |= test("gost2012_512", "A");
     ret |= test("gost2012_512", "B");
     ret |= test("gost2012_512", "C");
-
-    ENGINE_finish(eng);
-    ENGINE_free(eng);
 
     if (ret)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);


### PR DESCRIPTION
The following programs had a hard coded load of the gost engine.
This changes them to rely more on the testing environment, and to
load engines through configuration files.

This affects: test_ciphers.c, test_context.c, test_derive.c,
test_digest.c, test_params.c, test_sign.c, test_tls.c