### PR TITLE
Set OPENSSL_ROOT_DIR if it isn't set.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,14 @@ include(CheckCSourceRuns)
 enable_testing()
 
 find_package(OpenSSL 3.0 REQUIRED)
+
+if (NOT DEFINED OPENSSL_ROOT_DIR)
+  get_filename_component(OPENSSL_ROOT_DIR ${OPENSSL_INCLUDE_DIR} DIRECTORY)
+  message(STATUS "Setting OpenSSL root: ${OPENSSL_ROOT_DIR}")
+endif()
 find_program(OPENSSL_PROGRAM openssl
   PATHS ${OPENSSL_ROOT_DIR} PATH_SUFFIXES apps bin NO_DEFAULT_PATH)
-message("-- Found OpenSSL application: ${OPENSSL_PROGRAM}")
+message(STATUS "Found OpenSSL application: ${OPENSSL_PROGRAM}")
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 if (CMAKE_C_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
These days, the OpenSSL cmake package finder is capable of finding
a custom OpenSSL installation with no OPENSSL_ROOT_DIR defined, but
CMAKE_PREFIX_PATH defined.

However, gost-engine's CMakeLists.txt does use OPENSSL_ROOT_DIR, so
it needs it to be defined unconditionally.  That's arranged fairly
easily by assigning it the parent directory of OPENSSL_INCLUDE_DIR.