### PR TITLE
push VKO cofactor clearing into ECCKiila

### DIFF
--- a/ecp_id_tc26_gost_3410_2012_256_paramSetA.c
+++ b/ecp_id_tc26_gost_3410_2012_256_paramSetA.c
@@ -3674,6 +3674,9 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
     fiat_id_tc26_gost_3410_2012_256_paramSetA_selectznz(Q.Z, scalar[0] & 1,
                                                         lut.Z, Q.Z);
 
+    point_double(&Q, &Q);
+    point_double(&Q, &Q);
+
     /* move from Edwards projective to legacy projective */
     point_edwards2legacy(&Q, &Q);
     /* convert to affine -- NB depends on coordinate system */
@@ -8880,6 +8883,9 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[32],
                                                         lut.T, Q.T);
     fiat_id_tc26_gost_3410_2012_256_paramSetA_selectznz(Q.Z, scalar[0] & 1,
                                                         lut.Z, Q.Z);
+
+    point_double(&Q, &Q);
+    point_double(&Q, &Q);
 
     /* move from Edwards projective to legacy projective */
     point_edwards2legacy(&Q, &Q);

--- a/ecp_id_tc26_gost_3410_2012_512_paramSetC.c
+++ b/ecp_id_tc26_gost_3410_2012_512_paramSetC.c
@@ -4520,6 +4520,9 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
     fiat_id_tc26_gost_3410_2012_512_paramSetC_selectznz(Q.Z, scalar[0] & 1,
                                                         lut.Z, Q.Z);
 
+    point_double(&Q, &Q);
+    point_double(&Q, &Q);
+
     /* move from Edwards projective to legacy projective */
     point_edwards2legacy(&Q, &Q);
     /* convert to affine -- NB depends on coordinate system */
@@ -12446,6 +12449,9 @@ static void var_smul_rwnaf(pt_aff_t *out, const unsigned char scalar[64],
                                                         lut.T, Q.T);
     fiat_id_tc26_gost_3410_2012_512_paramSetC_selectznz(Q.Z, scalar[0] & 1,
                                                         lut.Z, Q.Z);
+
+    point_double(&Q, &Q);
+    point_double(&Q, &Q);
 
     /* move from Edwards projective to legacy projective */
     point_edwards2legacy(&Q, &Q);

--- a/gost_ec_keyx.c
+++ b/gost_ec_keyx.c
@@ -62,7 +62,12 @@ int VKO_compute_key(unsigned char *shared_key,
                        EC_GROUP_get0_order(grp), ctx))
         goto err;
 
-    /* these two curves have cofactor 4; the rest have cofactor 1 */
+#if 0
+    /*-
+     * These two curves have cofactor 4; the rest have cofactor 1.
+     * But currently gost_ec_point_mul takes care of the cofactor clearing,
+     * hence this code is not needed.
+     */
     switch (EC_GROUP_get_curve_name(grp)) {
         case NID_id_tc26_gost_3410_2012_256_paramSetA:
         case NID_id_tc26_gost_3410_2012_512_paramSetC:
@@ -70,6 +75,7 @@ int VKO_compute_key(unsigned char *shared_key,
                 goto err;
             break;
     }
+#endif
 
     if (!gost_ec_point_mul(grp, pnt, NULL, pub_key, scalar, ctx)) {
         GOSTerr(GOST_F_VKO_COMPUTE_KEY, GOST_R_ERROR_POINT_MUL);


### PR DESCRIPTION
Relates to [this ECCKiila issue](https://gitlab.com/nisec/ecckiila/-/issues/3).

@beldmit when you wrote

> is the current code in the GOST engine correct here? The KAT should be very useful, if possible

and I said it was fine, I was wrong :\ Sorry. I misread the rigging -- it was the OpenSSL rigging, not the GOST Engine rigging.

Anyway, here's the fix, and two KATs. If you apply only 41e89a6 to master, you should see the one failure. The 512-bit curve wasn't affected here, because ord(G) is slightly smaller than a power of two, in contrast to the 256-bit curve with ord(G) slightly larger than a power of two. In this regard, the `id_tc26_gost_3410_2012_256_paramSetA` parameters are slightly sub-optimal.

At least it wasn't a silent error, and the engine caught it when packing the BIGNUM to bytes and noticing the byte length mismatch :man_shrugging:

I made the EC changes by hand here. We'll get you the "real" ECCKiila changes once we close that issue.