### PR TITLE
Reduce cmake dependency info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ set_tests_properties(ciphers PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 # test_curves is an internals testing program, it doesn't need a test env
 add_executable(test_curves test_curves.c)
-target_link_libraries(test_curves gost_core ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_curves gost_core)
 add_test(NAME curves COMMAND test_curves)
 
 add_executable(test_params test_params.c)
@@ -245,12 +245,12 @@ set_tests_properties(context PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 # test_keyexpimp is an internals testing program, it doesn't need a test env
 add_executable(test_keyexpimp test_keyexpimp.c)
 #target_compile_definitions(test_keyexpimp PUBLIC -DOPENSSL_LOAD_CONF)
-target_link_libraries(test_keyexpimp gost_core ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_keyexpimp gost_core)
 add_test(NAME keyexpimp COMMAND test_keyexpimp)
 
 # test_gost89 is an internals testing program, it doesn't need a test env
 add_executable(test_gost89 test_gost89.c)
-target_link_libraries(test_gost89 gost_core ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_gost89 gost_core)
 add_test(NAME gost89 COMMAND test_gost89)
 
 if(NOT SKIP_PERL_TESTS)
@@ -266,7 +266,7 @@ if(NOT SKIP_PERL_TESTS)
 endif()
 
 add_executable(sign benchmark/sign.c)
-target_link_libraries(sign gost_core ${OPENSSL_CRYPTO_LIBRARIES} ${CLOCK_GETTIME_LIB})
+target_link_libraries(sign gost_core ${CLOCK_GETTIME_LIB})
 
 # All that may need to load just built engine will have path to it defined.
 set(BINARY_TESTS_TARGETS
@@ -285,6 +285,7 @@ set_property(TARGET ${BINARY_TESTS_TARGETS} APPEND PROPERTY COMPILE_DEFINITIONS 
 
 add_library(gost_core STATIC ${GOST_LIB_SOURCE_FILES})
 set_target_properties(gost_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(gost_core PRIVATE ${OPENSSL_CRYPTO_LIBRARIES})
 
 # The GOST engine in module form
 add_library(gost_engine MODULE ${GOST_ENGINE_SOURCE_FILES})
@@ -292,7 +293,7 @@ add_library(gost_engine MODULE ${GOST_ENGINE_SOURCE_FILES})
 # module suffix should be
 set_target_properties(gost_engine PROPERTIES
   PREFIX "" OUTPUT_NAME "gost" SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-target_link_libraries(gost_engine PRIVATE gost_core ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(gost_engine PRIVATE gost_core)
 
 # The GOST engine in library form
 add_library(lib_gost_engine SHARED ${GOST_ENGINE_SOURCE_FILES})
@@ -300,7 +301,7 @@ set_target_properties(lib_gost_engine PROPERTIES
   COMPILE_DEFINITIONS "BUILDING_ENGINE_AS_LIBRARY"
   PUBLIC_HEADER gost-engine.h
   OUTPUT_NAME "gost")
-target_link_libraries(lib_gost_engine PRIVATE gost_core ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(lib_gost_engine PRIVATE gost_core)
 
 
 set(GOST_SUM_SOURCE_FILES
@@ -308,7 +309,7 @@ set(GOST_SUM_SOURCE_FILES
         )
 
 add_executable(gostsum ${GOST_SUM_SOURCE_FILES})
-target_link_libraries(gostsum gost_core ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(gostsum gost_core)
 
 set(GOST_12_SUM_SOURCE_FILES
         gost12sum.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,12 +203,12 @@ set(TEST_ENVIRONMENT
         OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/test/engine.cnf
         )
 add_executable(test_digest test_digest.c)
-target_link_libraries(test_digest ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_digest OpenSSL::Crypto)
 add_test(NAME digest COMMAND test_digest)
 set_tests_properties(digest PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_ciphers test_ciphers.c)
-target_link_libraries(test_ciphers ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_ciphers OpenSSL::Crypto)
 add_test(NAME ciphers COMMAND test_ciphers)
 set_tests_properties(ciphers PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
@@ -218,27 +218,27 @@ target_link_libraries(test_curves gost_core)
 add_test(NAME curves COMMAND test_curves)
 
 add_executable(test_params test_params.c)
-target_link_libraries(test_params ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_params OpenSSL::Crypto)
 add_test(NAME parameters COMMAND test_params)
 set_tests_properties(parameters PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_derive test_derive.c)
-target_link_libraries(test_derive ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_derive OpenSSL::Crypto)
 add_test(NAME derive COMMAND test_derive)
 set_tests_properties(derive PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_sign test_sign.c)
-target_link_libraries(test_sign ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_sign OpenSSL::Crypto)
 add_test(NAME sign/verify COMMAND test_sign)
 set_tests_properties(sign/verify PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_tls test_tls.c)
-target_link_libraries(test_tls ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_tls OpenSSL::SSL)
 add_test(NAME TLS COMMAND test_tls)
 set_tests_properties(TLS PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_context test_context.c)
-target_link_libraries(test_context ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_context OpenSSL::Crypto)
 add_test(NAME context COMMAND test_context)
 set_tests_properties(context PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
@@ -285,7 +285,7 @@ set_property(TARGET ${BINARY_TESTS_TARGETS} APPEND PROPERTY COMPILE_DEFINITIONS 
 
 add_library(gost_core STATIC ${GOST_LIB_SOURCE_FILES})
 set_target_properties(gost_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(gost_core PRIVATE ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(gost_core PRIVATE OpenSSL::Crypto)
 
 # The GOST engine in module form
 add_library(gost_engine MODULE ${GOST_ENGINE_SOURCE_FILES})
@@ -333,7 +333,7 @@ add_custom_target(tcl_tests
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tcl_tests)
 
 add_executable(test_tlstree test_tlstree.c)
-target_link_libraries(test_tlstree PUBLIC ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(test_tlstree PUBLIC OpenSSL::Crypto)
 
 # install programs and manuals
 install(TARGETS gostsum gost12sum RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,54 +203,54 @@ set(TEST_ENVIRONMENT
         OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/test/engine.cnf
         )
 add_executable(test_digest test_digest.c)
-target_link_libraries(test_digest ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_digest ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME digest COMMAND test_digest)
 set_tests_properties(digest PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_ciphers test_ciphers.c)
-target_link_libraries(test_ciphers ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_ciphers ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME ciphers COMMAND test_ciphers)
 set_tests_properties(ciphers PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 # test_curves is an internals testing program, it doesn't need a test env
 add_executable(test_curves test_curves.c)
-target_link_libraries(test_curves gost_core ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_curves gost_core ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME curves COMMAND test_curves)
 
 add_executable(test_params test_params.c)
-target_link_libraries(test_params ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_params ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME parameters COMMAND test_params)
 set_tests_properties(parameters PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_derive test_derive.c)
-target_link_libraries(test_derive ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_derive ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME derive COMMAND test_derive)
 set_tests_properties(derive PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_sign test_sign.c)
-target_link_libraries(test_sign ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_sign ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME sign/verify COMMAND test_sign)
 set_tests_properties(sign/verify PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_tls test_tls.c)
-target_link_libraries(test_tls ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+target_link_libraries(test_tls ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME TLS COMMAND test_tls)
 set_tests_properties(TLS PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 add_executable(test_context test_context.c)
-target_link_libraries(test_context ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_context ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME context COMMAND test_context)
 set_tests_properties(context PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
 
 # test_keyexpimp is an internals testing program, it doesn't need a test env
 add_executable(test_keyexpimp test_keyexpimp.c)
 #target_compile_definitions(test_keyexpimp PUBLIC -DOPENSSL_LOAD_CONF)
-target_link_libraries(test_keyexpimp gost_core ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_keyexpimp gost_core ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME keyexpimp COMMAND test_keyexpimp)
 
 # test_gost89 is an internals testing program, it doesn't need a test env
 add_executable(test_gost89 test_gost89.c)
-target_link_libraries(test_gost89 gost_core ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_gost89 gost_core ${OPENSSL_CRYPTO_LIBRARIES})
 add_test(NAME gost89 COMMAND test_gost89)
 
 if(NOT SKIP_PERL_TESTS)
@@ -266,7 +266,7 @@ if(NOT SKIP_PERL_TESTS)
 endif()
 
 add_executable(sign benchmark/sign.c)
-target_link_libraries(sign gost_core ${OPENSSL_CRYPTO_LIBRARY} ${CLOCK_GETTIME_LIB})
+target_link_libraries(sign gost_core ${OPENSSL_CRYPTO_LIBRARIES} ${CLOCK_GETTIME_LIB})
 
 # All that may need to load just built engine will have path to it defined.
 set(BINARY_TESTS_TARGETS
@@ -292,7 +292,7 @@ add_library(gost_engine MODULE ${GOST_ENGINE_SOURCE_FILES})
 # module suffix should be
 set_target_properties(gost_engine PROPERTIES
   PREFIX "" OUTPUT_NAME "gost" SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-target_link_libraries(gost_engine PRIVATE gost_core ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(gost_engine PRIVATE gost_core ${OPENSSL_CRYPTO_LIBRARIES})
 
 # The GOST engine in library form
 add_library(lib_gost_engine SHARED ${GOST_ENGINE_SOURCE_FILES})
@@ -300,7 +300,7 @@ set_target_properties(lib_gost_engine PROPERTIES
   COMPILE_DEFINITIONS "BUILDING_ENGINE_AS_LIBRARY"
   PUBLIC_HEADER gost-engine.h
   OUTPUT_NAME "gost")
-target_link_libraries(lib_gost_engine PRIVATE gost_core ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(lib_gost_engine PRIVATE gost_core ${OPENSSL_CRYPTO_LIBRARIES})
 
 
 set(GOST_SUM_SOURCE_FILES
@@ -308,7 +308,7 @@ set(GOST_SUM_SOURCE_FILES
         )
 
 add_executable(gostsum ${GOST_SUM_SOURCE_FILES})
-target_link_libraries(gostsum gost_core ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(gostsum gost_core ${OPENSSL_CRYPTO_LIBRARIES})
 
 set(GOST_12_SUM_SOURCE_FILES
         gost12sum.c
@@ -332,7 +332,7 @@ add_custom_target(tcl_tests
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tcl_tests)
 
 add_executable(test_tlstree test_tlstree.c)
-target_link_libraries(test_tlstree PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(test_tlstree PUBLIC ${OPENSSL_CRYPTO_LIBRARIES})
 
 # install programs and manuals
 install(TARGETS gostsum gost12sum RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
## Make CMakeLists.txt work better with static OpenSSL libraries

The static OpenSSL libraries have some dependencies that need to be
recorded fofr everything that's linked against it.  To achieve this,
we use ${OPENSSL_CRYPTO_LIBRARIES} and ${OPENSSL_SSL_LIBRARIES}
instead of ${OPENSSL_CRYPTO_LIBRARY} and ${OPENSSL_SSL_LIBRARY}.

## Reduce the repeated library dependence information

Cmake is generally good at tracking specified dependencies between
libraries.  All that we need to do is to establish a dependency on
OpenSSL's libcrypto for 'gost_core', and then we can reduce the amount
of repeated dependencies for everything that links against 'gost_core'.

## Switch to using OpenSSL target names in CMakeLists.txt

Cmake 3.0 was a switch to using targets and properties rather than
variables when linking different components together.
We follow that philosophy by dropping ${OPENSSL_CRYPTO_LIBRARIES} and
${OPENSSL_SSL_LIBRARIES} in favor of OpenSSL::Crypto and OpenSSL::SSL.