### PR TITLE
Prevent crash by not loading engine if there is multiple libcrypto.so

### DIFF
--- a/gost_eng.c
+++ b/gost_eng.c
@@ -8,6 +8,10 @@
  *       This file is distributed under the same license as OpenSSL   *
  *                                                                    *
  **********************************************************************/
+#ifdef __linux__
+# define _GNU_SOURCE
+# include <link.h>
+#endif
 #include <string.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
@@ -424,8 +428,29 @@ static int bind_gost_engine(ENGINE* e) {
     return ret;
 }
 
+#ifdef __linux__
+static int libcrypto_so_count = 0;
+
+static int gost_dl_callback(struct dl_phdr_info *info, size_t size, void *data)
+{
+    if (strstr(info->dlpi_name, "libcrypto.so"))
+        libcrypto_so_count++;
+
+    return 0;
+}
+#endif
+
 static int check_gost_engine(ENGINE* e, const char* id)
 {
+#ifdef __linux__
+    /* Sanity check to prevent crash of gost.so loading by wrong libcrypto.so. */
+    dl_iterate_phdr(gost_dl_callback, NULL);
+    if (libcrypto_so_count > 1) {
+        fprintf(stderr, "error:%s:%d: Multiple instances of libcrypto.so, %s engine wont load to prevent crashes.\n",
+                __FILE__, __LINE__, id);
+        return 0;
+    }
+#endif
     if (id != NULL && strcmp(id, engine_gost_id) != 0)
         return 0;
     if (ameth_GostR3410_2001) {


### PR DESCRIPTION
If libcrypto.so.1 loads engine compiled for libcrypto.so.3 crash is
imminent. Avoid the crash by not loading engine at all if there is two
libcrypto.so. There cannot be two libcrypto.so.1 or two libcrypto.so.3,
so this workaround seems good.

Link: https://github.com/openssl/openssl/issues/17102
Signed-off-by: Vitaly Chikunov <vt@altlinux.org>