### PR TITLE
test_tls: Rework test to be single process

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Build OpenSSL
               if: steps.cache.outputs.cache-hit != 'true'
               run: |
-                  perl Configure no-makedepend no-tests no-asm
+                  perl Configure no-makedepend no-tests no-asm VC-WIN64A
                   perl configdata.pm --dump
                   nmake /S build_libs build_programs
                   nmake /S install_sw DESTDIR=_dest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,13 +269,11 @@ add_test(NAME sign/verify-with-engine COMMAND test_sign)
 set_tests_properties(sign/verify-with-engine
   PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT_ENGINE}")
 
-if(NOT MSVC)
-  add_executable(test_tls test_tls.c)
-  target_link_libraries(test_tls OpenSSL::SSL)
-  add_test(NAME TLS-with-engine COMMAND test_tls)
-  set_tests_properties(TLS-with-engine
-    PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT_ENGINE}")
-endif()
+add_executable(test_tls test_tls.c)
+target_link_libraries(test_tls OpenSSL::SSL)
+add_test(NAME TLS-with-engine COMMAND test_tls)
+set_tests_properties(TLS-with-engine
+  PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT_ENGINE}")
 
 add_executable(test_context test_context.c)
 target_link_libraries(test_context OpenSSL::Crypto)
@@ -329,10 +327,8 @@ set(BINARY_TESTS_TARGETS
         test_context
         test_keyexpimp
         test_gost89
+        test_tls
         )
-if(NOT MSVC)
-  list(APPEND BINARY_TESTS_TARGETS test_tls)
-endif()
 set_property(TARGET ${BINARY_TESTS_TARGETS} APPEND PROPERTY COMPILE_DEFINITIONS ENGINE_DIR="${OUTPUT_DIRECTORY}")
 
 add_library(gost_core STATIC ${GOST_LIB_SOURCE_FILES})

--- a/test_tls.c
+++ b/test_tls.c
@@ -225,8 +225,8 @@ static struct certkey certgen(const char *algname, const char *paramset)
     T(X509_REQ_set_version(req, 0L));
     X509_NAME *name;
     T(name = X509_NAME_new());
-    T(X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, "Test CA", -1, -1, 0));
-    T(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, "Test Key", -1, -1, 0));
+    T(X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char *)"Test CA", -1, -1, 0));
+    T(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char *)"Test Key", -1, -1, 0));
     T(X509_REQ_set_subject_name(req, name));
     T(X509_REQ_set_pubkey(req, pkey));
     X509_NAME_free(name);


### PR DESCRIPTION
Rework the test to be similar to sslapitest.c. Using BIO only connections
and non-blocking IO instead of socketpair and separate processes.
This will allow it to compile and work on Windows.

Thus, re-enable test on Windows.
