### PR TITLE
Fix gcc12 -fanalyzer warning

### DIFF
--- a/test_sign.c
+++ b/test_sign.c
@@ -121,6 +121,9 @@ static int test_sign(struct test_sign *t)
 	case 512:
 	    type = NID_id_GostR3410_2012_512;
 	    algname = "gost2012_512";
+	    break;
+	default:
+	    return -1;
     }
 
     /* Keygen. */


### PR DESCRIPTION
GCC do not understand that `algname` cannot be NULL. Add dummy default case to
cover all execution paths.

Fixes https://github.com/gost-engine/engine/issues/389
