### PR TITLE
patches: improve SSL_trace output

### DIFF
--- a/patches/openssl_111r.diff
+++ b/patches/openssl_111r.diff
@@ -3232,20 +3232,24 @@ index 5f657f88..0ef8dc06 100644
              }
              if (i == num)
 diff --git ssl/t1_trce.c ssl/t1_trce.c
-index e2c397b7..9d7341da 100644
+index e2c397b7..6ac31513 100644
 --- ssl/t1_trce.c
 +++ ssl/t1_trce.c
-@@ -443,6 +443,9 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
+@@ -443,6 +443,13 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
      {0xFEFF, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA"},
      {0xFF85, "GOST2012-GOST8912-GOST8912"},
      {0xFF87, "GOST2012-NULL-GOST12"},
 +    {0xC100, "GOST2012-KUZNYECHIK-KUZNYECHIKOMAC"},
 +    {0xC101, "GOST2012-MAGMA-MAGMAOMAC"},
 +    {0xC102, "GOST2012-GOST8912-IANA"},
++    {0xC103, "TLS_GOSTR341112_256_WITH_KUZNYECHIK_MGM_L"},
++    {0xC104, "TLS_GOSTR341112_256_WITH_MAGMA_MGM_L"},
++    {0xC105, "TLS_GOSTR341112_256_WITH_KUZNYECHIK_MGM_S"},
++    {0xC106, "TLS_GOSTR341112_256_WITH_MAGMA_MGM_S"},
  };
  
  /* Compression methods */
-@@ -522,6 +525,13 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
+@@ -522,6 +529,13 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
      {28, "brainpoolP512r1"},
      {29, "ecdh_x25519"},
      {30, "ecdh_x448"},
@@ -3259,8 +3263,17 @@ index e2c397b7..9d7341da 100644
      {256, "ffdhe2048"},
      {257, "ffdhe3072"},
      {258, "ffdhe4096"},
-@@ -571,6 +581,8 @@ static const ssl_trace_tbl ssl_sigalg_tbl[] = {
+@@ -569,8 +583,17 @@ static const ssl_trace_tbl ssl_sigalg_tbl[] = {
+     {TLSEXT_SIGALG_dsa_sha512, "dsa_sha512"},
+     {TLSEXT_SIGALG_dsa_sha224, "dsa_sha224"},
      {TLSEXT_SIGALG_dsa_sha1, "dsa_sha1"},
++    {TLSEXT_SIGALG_gostr34102012_256a, "gostr34102012_256a"},
++    {TLSEXT_SIGALG_gostr34102012_256b, "gostr34102012_256b"},
++    {TLSEXT_SIGALG_gostr34102012_256c, "gostr34102012_256c"},
++    {TLSEXT_SIGALG_gostr34102012_256d, "gostr34102012_256d"},
++    {TLSEXT_SIGALG_gostr34102012_512a, "gostr34102012_512a"},
++    {TLSEXT_SIGALG_gostr34102012_512b, "gostr34102012_512b"},
++    {TLSEXT_SIGALG_gostr34102012_512c, "gostr34102012_512c"},
      {TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256, "gost2012_256"},
      {TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512, "gost2012_512"},
 +    {TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256_legacy, "gost2012_256"},
@@ -3268,7 +3281,7 @@ index e2c397b7..9d7341da 100644
      {TLSEXT_SIGALG_gostr34102001_gostr3411, "gost2001_gost94"},
  };
  
-@@ -584,7 +596,9 @@ static const ssl_trace_tbl ssl_ctype_tbl[] = {
+@@ -584,7 +607,9 @@ static const ssl_trace_tbl ssl_ctype_tbl[] = {
      {20, "fortezza_dms"},
      {64, "ecdsa_sign"},
      {65, "rsa_fixed_ecdh"},
@@ -3279,7 +3292,7 @@ index e2c397b7..9d7341da 100644
  };
  
  static const ssl_trace_tbl ssl_psk_kex_modes_tbl[] = {
-@@ -1077,6 +1091,10 @@ static int ssl_get_keyex(const char **pname, const SSL *ssl)
+@@ -1077,6 +1102,10 @@ static int ssl_get_keyex(const char **pname, const SSL *ssl)
          *pname = "GOST";
          return SSL_kGOST;
      }
@@ -3290,7 +3303,7 @@ index e2c397b7..9d7341da 100644
      *pname = "UNKNOWN";
      return 0;
  }
-@@ -1119,7 +1137,16 @@ static int ssl_print_client_keyex(BIO *bio, int indent, const SSL *ssl,
+@@ -1119,7 +1148,16 @@ static int ssl_print_client_keyex(BIO *bio, int indent, const SSL *ssl,
          if (!ssl_print_hexbuf(bio, indent + 2, "ecdh_Yc", 1, &msg, &msglen))
              return 0;
          break;


### PR DESCRIPTION
This PR improve openssl trace output (commands 's_client'/'s_server' with '-trace' option). Some gost cipher suites and signature algorithms outputs as ''UNKNOWN'. See output example below.
This is true for new added TLS1.3 cipher suites and signature algorithms.

example output (s_client '-trace -ciphersuites TLS_GOSTR341112_256_WITH_MAGMA_MGM_L -curves GC256A'):
```
Sent Record
Header:
  Version = TLS 1.0 (0x301)
  Content Type = Handshake (22)
  Length = 342
    ClientHello, Length=338
      client_version=0x303 (TLS 1.2)
      Random:
        ...
      session_id (len=32): AFB80D71BE56675B2FF7460129AD64875D02C3EA23A61D43120B02D1439C8CEC
      cipher_suites (len=68)
        {0xC1, 0x04} UNKNOWN
        ...
      compression_methods (len=1)
        ...
      extensions, length = 197
        extension_type=ec_point_formats(11), length=4
          ...
        extension_type=supported_groups(10), length=4
          GC256A (34)
        extension_type=session_ticket(35), length=0
        extension_type=encrypt_then_mac(22), length=0
        extension_type=extended_master_secret(23), length=0
        extension_type=signature_algorithms(13), length=72
          ...
          UNKNOWN (0x0709)
          UNKNOWN (0x070a)
          UNKNOWN (0x070b)
          UNKNOWN (0x070c)
          UNKNOWN (0x070d)
          UNKNOWN (0x070e)
          UNKNOWN (0x070f)
          gost2012_256 (0x0840)
          gost2012_512 (0x0841)
          gost2012_256 (0xeeee)
          gost2012_512 (0xefef)
          gost2001_gost94 (0xeded)
        extension_type=supported_versions(43), length=9
          TLS 1.3 (772)
          TLS 1.2 (771)
          TLS 1.1 (770)
          TLS 1.0 (769)
        extension_type=psk_key_exchange_modes(45), length=2
          psk_dhe_ke (1)
        extension_type=key_share(51), length=70
            ...
```