### PR TITLE
Correct CMake files installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,5 +449,5 @@ if (MSVC)
   install(FILES $<TARGET_PDB_FILE:gost_prov>
     EXPORT GostProviderConfig DESTINATION ${OPENSSL_MODULES_DIR} OPTIONAL)
 endif()
-install(EXPORT GostEngineConfig DESTINATION GostEngine/share/cmake/GostEngine)
-install(EXPORT GostProviderConfig DESTINATION GostEngine/share/cmake/GostProvider)
+install(EXPORT GostEngineConfig DESTINATION share/cmake/GostEngine)
+install(EXPORT GostProviderConfig DESTINATION share/cmake/GostProvider)


### PR DESCRIPTION
install(EXPORT GostEngineConfig DESTINATION share/cmake/GostEngine) will to a path like this: /usr/GostEngine/share/cmake/GostEngine/GostEngineConfig.cmake which is not standard or expected. These files should be installed to: /usr/share/cmake/GostEngine/GostEngineConfig.cmake which can be done by changing the installation line to: install(EXPORT GostEngineConfig DESTINATION share/cmake/GostEngine)