### PR TITLE
Added missing buffer cleanses for some sensitive buffers

### DIFF
--- a/gost_crypt.c
+++ b/gost_crypt.c
@@ -529,6 +529,7 @@ static int magma_cipher_init_ctr_acpkm_omac(EVP_CIPHER_CTX *ctx, const unsigned 
 	if (key) {
     struct ossl_gost_cipher_ctx *c = EVP_CIPHER_CTX_get_cipher_data(ctx);
 		unsigned char cipher_key[32];
+        int ret;
 		c->omac_ctx = EVP_MD_CTX_new();
 
 		if (c->omac_ctx == NULL) {
@@ -543,7 +544,9 @@ static int magma_cipher_init_ctr_acpkm_omac(EVP_CIPHER_CTX *ctx, const unsigned 
 		    return 0;
 		}
 
-		return magma_cipher_init(ctx, cipher_key, iv, enc);
+		ret = magma_cipher_init(ctx, cipher_key, iv, enc);
+        OPENSSL_cleanse(cipher_key, sizeof(cipher_key));
+        return ret;
 	}
 
 	return magma_cipher_init(ctx, key, iv, enc);
@@ -1324,6 +1327,7 @@ static int magma_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), adjusted_iv, 8);
 
                 magma_key(c, newkey);
+                OPENSSL_cleanse(newkey, sizeof(newkey));
                 return 1;
           }
         }

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -175,6 +175,7 @@ static void acpkm_next(gost_grasshopper_cipher_ctx * c)
                                   &c->buffer);
     }
     gost_grasshopper_cipher_key(c, newkey);
+    OPENSSL_cleanse(newkey, sizeof(newkey));
 }
 
 /* Set 256 bit  key into context */
@@ -351,6 +352,7 @@ gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX
 
     if (key) {
         unsigned char cipher_key[32];
+        int ret;
         c->omac_ctx = EVP_MD_CTX_new();
 
         if (c->omac_ctx == NULL) {
@@ -365,7 +367,9 @@ gost_grasshopper_cipher_init_ctracpkm_omac(EVP_CIPHER_CTX
             return 0;
         }
 
-        return gost_grasshopper_cipher_init(ctx, cipher_key, iv, enc);
+        ret = gost_grasshopper_cipher_init(ctx, cipher_key, iv, enc);
+        OPENSSL_cleanse(cipher_key, sizeof(cipher_key));
+        return ret;
     }
 
     return gost_grasshopper_cipher_init(ctx, key, iv, enc);
@@ -1158,6 +1162,7 @@ static int gost_grasshopper_cipher_ctl(EVP_CIPHER_CTX *ctx, int type, int arg, v
             memcpy(EVP_CIPHER_CTX_iv_noconst(ctx), adjusted_iv, 16);
 
             gost_grasshopper_cipher_key(c, newkey);
+            OPENSSL_cleanse(newkey, sizeof(newkey));
             return 1;
           }
         }

--- a/gost_keyexpimp.c
+++ b/gost_keyexpimp.c
@@ -269,6 +269,7 @@ int gost_tlstree(int cipher_nid, const unsigned char *in, unsigned char *out,
     uint64_t seed1, seed2, seed3;
     uint64_t seq;
     unsigned char ko1[32], ko2[32];
+    int ret;
 
     switch (cipher_nid) {
     case NID_magma_cbc:
@@ -293,15 +294,16 @@ int gost_tlstree(int cipher_nid, const unsigned char *in, unsigned char *out,
     seed2 = seq & c2;
     seed3 = seq & c3;
 
-    if (gost_kdftree2012_256(ko1, 32, in, 32, (const unsigned char *)"level1", 6,
+    ret = !(gost_kdftree2012_256(ko1, 32, in, 32, (const unsigned char *)"level1", 6,
                          (const unsigned char *)&seed1, 8, 1) <= 0
 			  || gost_kdftree2012_256(ko2, 32, ko1, 32, (const unsigned char *)"level2", 6,
                          (const unsigned char *)&seed2, 8, 1) <= 0
         || gost_kdftree2012_256(out, 32, ko2, 32, (const unsigned char *)"level3", 6,
-                         (const unsigned char *)&seed3, 8, 1) <= 0)
-			return 0;
+                         (const unsigned char *)&seed3, 8, 1) <= 0);
 
-    return 1;
+    OPENSSL_cleanse(ko1, sizeof(ko1));
+    OPENSSL_cleanse(ko2, sizeof(ko2));
+    return ret;
 }
 
 #define GOST_WRAP_FLAGS  EVP_CIPH_CTRL_INIT | EVP_CIPH_WRAP_MODE | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER | EVP_CIPH_FLAG_DEFAULT_ASN1

--- a/gost_omac.c
+++ b/gost_omac.c
@@ -249,6 +249,7 @@ int omac_imit_ctrl(EVP_MD_CTX *ctx, int type, int arg, void *ptr)
                         || (cipher = EVP_CIPHER_fetch(NULL, c->cipher_name, NULL)))
                         ret = omac_key(c, cipher, diversed_key, 32);
                     EVP_CIPHER_free(cipher);
+                    OPENSSL_cleanse(diversed_key, sizeof(diversed_key));
                 }
                 return ret;
             }


### PR DESCRIPTION
Added missing OPENSSL_cleanse calls for stack-based buffers during key derivation (OMAC, TLSTREE).