### PR TITLE
Fix static analysis (Infer) complains

### DIFF
--- a/gost12sum.c
+++ b/gost12sum.c
@@ -250,7 +250,7 @@ int hash_stream(gost_hash_ctx * ctx, int fd, char *sum, int hashsize)
 int get_line(FILE *f, char *hash, char *filename, int verbose, int *size)
 {
     int i, len;
-    char *ptr = filename;
+    char *ptr;
     char *spacepos = NULL;
 
     while (!feof(f)) {

--- a/test_digest.c
+++ b/test_digest.c
@@ -663,6 +663,7 @@ static int do_mac(int iter, EVP_MAC *mac, const char *plaintext,
     }
     else
         outsize = EVP_MAC_CTX_get_mac_size(ctx);
+    T(p - params < 4);
 
     T(EVP_MAC_init(ctx, (const unsigned char *)t->key, t->key_size, NULL));
     T(EVP_MAC_CTX_set_params(ctx, params));

--- a/test_tls.c
+++ b/test_tls.c
@@ -78,7 +78,7 @@ static void err(int eval, const char *fmt, ...)
 }
 
 /* Generate simple cert+key pair. Based on req.c */
-static struct certkey certgen(const char *algname, const char *paramset)
+static void certgen(const char *algname, const char *paramset, struct certkey *ck)
 {
     /* Keygen. */
     EVP_PKEY *tkey;
@@ -150,7 +150,8 @@ static struct certkey certgen(const char *algname, const char *paramset)
     PEM_write_bio_X509(out, x509ss);
     BIO_free_all(out);
 #endif
-    return (struct certkey){ .pkey = pkey, .cert = x509ss };
+    ck->pkey = pkey;
+    ck->cert = x509ss;
 }
 
 /* Non-blocking BIO test mechanic is based on sslapitest.c */
@@ -164,7 +165,7 @@ int test(const char *algname, const char *paramset)
     printf(cNORM "\n");
 
     struct certkey ck;
-    ck = certgen(algname, paramset);
+    certgen(algname, paramset, &ck);
 
     SSL_CTX *cctx, *sctx;
 


### PR DESCRIPTION
Infer выдаёт четыре замечания к коду, все несущественные, три точно ложно положительные. На случай, если будет желание включить статический анализ в тесты, я все четыре починил.

```
$ infer run --compilation-database build/compile_commands.json
Capturing using compilation database...
Starting translating 53 files
53/53 [##############################################################################] 100% 5.34s

Found 53 source files to analyze in /home/s/src/crypto/engine/infer-out
Skipped large procedure (__infer_globals_initializer_grasshopper_pil_enc128, size:65543) in pulse.
Skipped large procedure (__infer_globals_initializer_grasshopper_pil_dec128, size:65543) in pulse.
Skipped large procedure (__infer_globals_initializer_grasshopper_l_dec128, size:65543) in pulse.
1161/1161 [##########################################################################] 100% 15.5s

gost12sum.c:253: error: Dead Store
  The value written to `&ptr` is never used. 
  251. {
  252.     int i, len;
  253.     char *ptr = filename;
           ^
  254.     char *spacepos = NULL;
  255. 

test_digest.c:662: error: Dead Store
  The value written to `&p` is never used. 
  660.     if (t->truncate) {
  661.         outsize = t->truncate;
  662. 	*p++ = OSSL_PARAM_construct_size_t("size", &outsize);
         ^
  663.     }
  664.     else

test_tls.c:172: error: Uninitialized Value
  `_.cert` is read without initialization. 
  170. 
  171.     T(sctx = SSL_CTX_new(TLS_server_method()));
  172.     T(SSL_CTX_use_certificate(sctx, ck.cert));
           ^
  173.     T(SSL_CTX_use_PrivateKey(sctx, ck.pkey));
  174.     T(SSL_CTX_check_private_key(sctx));

test_tls.c:173: error: Uninitialized Value
  `_.pkey` is read without initialization. 
  171.     T(sctx = SSL_CTX_new(TLS_server_method()));
  172.     T(SSL_CTX_use_certificate(sctx, ck.cert));
  173.     T(SSL_CTX_use_PrivateKey(sctx, ck.pkey));
           ^
  174.     T(SSL_CTX_check_private_key(sctx));
  175. 


Found 4 issues
                      Issue Type(ISSUED_TYPE_ID): #
  Uninitialized Value(PULSE_UNINITIALIZED_VALUE): 2
                          Dead Store(DEAD_STORE): 2
```