### PR TITLE
test: parallel testsuite runs failed due to reused filenames

### DIFF
--- a/test/00-engine.t
+++ b/test/00-engine.t
@@ -7,7 +7,7 @@ use Cwd 'abs_path';
 
 # prepare data for 
 
-open (my $F,">","testdata.dat");
+open (my $F,">","$ARGV[0]-testdata.dat");
 print $F "12345670" x 128;
 close $F;
 
@@ -49,8 +49,8 @@ is(`openssl engine -c $engine`,
 $engine_info,
 "load engine without any config");
 
-is(`openssl dgst -engine $engine -md_gost94 testdata.dat`,
-"md_gost94(testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
+is(`openssl dgst -engine $engine -md_gost94 $ARGV[0]-testdata.dat`,
+"md_gost94($ARGV[0]-testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
 "compute digest without config");
 
 
@@ -72,17 +72,17 @@ is(`openssl engine -c $engine`,
 $engine_info,
 "load engine with config");
 
-is(`openssl dgst -md_gost94 testdata.dat`,
-"md_gost94(testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
+is(`openssl dgst -md_gost94 $ARGV[0]-testdata.dat`,
+"md_gost94($ARGV[0]-testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
 "compute digest with config without explicit engine param");
 
-is(`openssl dgst -engine $engine -md_gost94 testdata.dat`,
-"md_gost94(testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
+is(`openssl dgst -engine $engine -md_gost94 $ARGV[0]-testdata.dat`,
+"md_gost94($ARGV[0]-testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\n",
 "compute digest with both config and explicit engine param");
 
 like(`openssl ciphers`, qr|GOST2001-GOST89-GOST89|, 'display GOST2001-GOST89-GOST89 cipher');
 
 like(`openssl ciphers`, qr|GOST2012-GOST8912-GOST8912|, 'display GOST2012-GOST8912-GOST8912 cipher');
 
-unlink('testdata.dat');
+unlink("$ARGV[0]-testdata.dat");
 unlink('test.cnf');

--- a/test/01-digest.t
+++ b/test/01-digest.t
@@ -98,170 +98,170 @@ foreach my $test_type (@test_types) {
     my $cmd;
     my $name_re;
 
-    open $F,">","testm1.dat";
+    open $F,">","$ARGV[0]-testm1.dat";
     print $F "012345678901234567890123456789012345678901234567890123456789012";
     close $F;
-    $cmd = "openssl dgst${module_args} -md_gost12_256 testm1.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_256 $ARGV[0]-testm1.dat";
     $name_re = qr/id-tc26-gost3411-12-256|md_gost12_256/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testm1.dat)= 9d151eefd8590b89daa6ba6cb74af9275dd051026bb149a452fd84e5e57b5500\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testm1.dat)= 9d151eefd8590b89daa6ba6cb74af9275dd051026bb149a452fd84e5e57b5500\E\n$/ms,
                  "GOST R 34.11-2012 256bit example 1 from standard")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_512 testm1.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_512 $ARGV[0]-testm1.dat";
     $name_re = qr/id-tc26-gost3411-12-512|md_gost12_512/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testm1.dat)= 1b54d01a4af5b9d5cc3d86d68d285462b19abc2475222f35c085122be4ba1ffa00ad30f8767b3a82384c6574f024c311e2a481332b08ef7f41797891c1646f48\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testm1.dat)= 1b54d01a4af5b9d5cc3d86d68d285462b19abc2475222f35c085122be4ba1ffa00ad30f8767b3a82384c6574f024c311e2a481332b08ef7f41797891c1646f48\E\n$/ms,
                  "GOST R 34.11-2012 512bit example 1 from standard")) {
         diag("Command was: $cmd");
     }
 
-    unlink("testm1.dat");
+    unlink("$ARGV[0]-testm1.dat");
 
 
-    open $F,">","testm2.dat";
+    open $F,">","$ARGV[0]-testm2.dat";
     print $F pack("H*","d1e520e2e5f2f0e82c20d1f2f0e8e1eee6e820e2edf3f6e82c20e2e5fef2fa20f120eceef0ff20f1f2f0e5ebe0ece820ede020f5f0e0e1f0fbff20efebfaeafb20c8e3eef0e5e2fb");
     close $F;
-    $cmd = "openssl dgst${module_args} -md_gost12_256 testm2.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_256 $ARGV[0]-testm2.dat";
     $name_re = qr/id-tc26-gost3411-12-256|md_gost12_256/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testm2.dat)= 9dd2fe4e90409e5da87f53976d7405b0c0cac628fc669a741d50063c557e8f50\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testm2.dat)= 9dd2fe4e90409e5da87f53976d7405b0c0cac628fc669a741d50063c557e8f50\E\n$/ms,
                  "GOST R 34.11-2012 256bit example 2 from standard")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_512 testm2.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_512 $ARGV[0]-testm2.dat";
     $name_re = qr/id-tc26-gost3411-12-512|md_gost12_512/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testm2.dat)= 1e88e62226bfca6f9994f1f2d51569e0daf8475a3b0fe61a5300eee46d961376035fe83549ada2b8620fcd7c496ce5b33f0cb9dddc2b6460143b03dabac9fb28\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testm2.dat)= 1e88e62226bfca6f9994f1f2d51569e0daf8475a3b0fe61a5300eee46d961376035fe83549ada2b8620fcd7c496ce5b33f0cb9dddc2b6460143b03dabac9fb28\E\n$/ms,
                  "GOST R 34.11-2012 512bit example 2 from standard")) {
         diag("Command was: $cmd");
     }
 
-    unlink("testm2.dat");
+    unlink("$ARGV[0]-testm2.dat");
 
 
-    open $F,">","testdata.dat";
+    open $F,">","$ARGV[0]-testdata.dat";
     binmode $F;
     print $F "12345670" x 128;
     close $F;
-    $cmd = "openssl dgst${module_args} -md_gost94 testdata.dat";
+    $cmd = "openssl dgst${module_args} -md_gost94 $ARGV[0]-testdata.dat";
     $name_re = qr/id-GostR3411-94|md_gost94/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata.dat)= f7fc6d16a6a5c12ac4f7d320e0fd0d8354908699125e09727a4ef929122b1cae\E\n$/ms,
                  "GOST R 34.11-94 1K ascii")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_256 testdata.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_256 $ARGV[0]-testdata.dat";
     $name_re = qr/id-tc26-gost3411-12-256|md_gost12_256/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata.dat)= 1906512b86a1283c68cec8419e57113efc562a1d0e95d8f4809542900c416fe4\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata.dat)= 1906512b86a1283c68cec8419e57113efc562a1d0e95d8f4809542900c416fe4\E\n$/ms,
                  "GOST R 34.11-2012 256bit 1K ascii")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_512 testdata.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_512 $ARGV[0]-testdata.dat";
     $name_re = qr/id-tc26-gost3411-12-512|md_gost12_512/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata.dat)= 283587e434864d0d4bea97c0fb10e2dd421572fc859304bdf6a94673d652c59049212bad7802b4fcf5eecc1f8fab569d60f2c20dbd789a7fe4efbd79d8137ee7\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata.dat)= 283587e434864d0d4bea97c0fb10e2dd421572fc859304bdf6a94673d652c59049212bad7802b4fcf5eecc1f8fab569d60f2c20dbd789a7fe4efbd79d8137ee7\E\n$/ms,
                  "GOST R 34.11-2012 512bit 1K ascii")) {
         diag("Command was: $cmd");
     }
 
-    unlink("testdata.dat");
+    unlink("$ARGV[0]-testdata.dat");
 
 
-    open $F,">","testdata2.dat";
+    open $F,">","$ARGV[0]-testdata2.dat";
     binmode $F;
     print $F "\x00\x01\x02\x15\x84\x67\x45\x31" x 128;
     close $F;
 
-    $cmd = "openssl dgst${module_args} -md_gost94 testdata2.dat";
+    $cmd = "openssl dgst${module_args} -md_gost94 $ARGV[0]-testdata2.dat";
     $name_re = qr/id-GostR3411-94|md_gost94/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata2.dat)= 69f529aa82d9344ab0fa550cdf4a70ecfd92a38b5520b1906329763e09105196\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata2.dat)= 69f529aa82d9344ab0fa550cdf4a70ecfd92a38b5520b1906329763e09105196\E\n$/ms,
                  "GOST R 34.11-94 1K binary")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_256 testdata2.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_256 $ARGV[0]-testdata2.dat";
     $name_re = qr/id-tc26-gost3411-12-256|md_gost12_256/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata2.dat)= 2eb1306be3e490f18ff0e2571a077b3831c815c46c7d4fdf9e0e26de4032b3f3\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata2.dat)= 2eb1306be3e490f18ff0e2571a077b3831c815c46c7d4fdf9e0e26de4032b3f3\E\n$/ms,
                  "GOST R 34.11-2012 256bit 1K binary")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_512 testdata2.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_512 $ARGV[0]-testdata2.dat";
     $name_re = qr/id-tc26-gost3411-12-512|md_gost12_512/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata2.dat)= 55656e5bcf795b499031a7833cd7dc18fe10d4a47e15be545c6ab3f304a4fe411c4c39de5b1fc6844880111441e0b92bf1ec2fb7840453fe39a2b70ced461968\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata2.dat)= 55656e5bcf795b499031a7833cd7dc18fe10d4a47e15be545c6ab3f304a4fe411c4c39de5b1fc6844880111441e0b92bf1ec2fb7840453fe39a2b70ced461968\E\n$/ms,
                  "GOST R 34.11-2012 512bit 1K binary")) {
         diag("Command was: $cmd");
     }
 
-    unlink("testdata2.dat");
+    unlink("$ARGV[0]-testdata2.dat");
 
-    open $F, ">","testdata3.dat";
+    open $F, ">","$ARGV[0]-testdata3.dat";
     binmode $F;
     print $F substr("12345670" x 128,0,539);
     close $F;
 
-    $cmd = "openssl dgst${module_args} -md_gost94 testdata3.dat";
+    $cmd = "openssl dgst${module_args} -md_gost94 $ARGV[0]-testdata3.dat";
     $name_re = qr/id-GostR3411-94|md_gost94/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata3.dat)= bd5f1e4b539c7b00f0866afdbc8ed452503a18436061747a343f43efe888aac9\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata3.dat)= bd5f1e4b539c7b00f0866afdbc8ed452503a18436061747a343f43efe888aac9\E\n$/ms,
                  "GOST R 34.11-94 539 bytes")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_256 testdata3.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_256 $ARGV[0]-testdata3.dat";
     $name_re = qr/id-tc26-gost3411-12-256|md_gost12_256/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata3.dat)= c98a17f9fadff78d08521e4179a7b2e6275f3b1da88339a3cb961a3514e5332e\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata3.dat)= c98a17f9fadff78d08521e4179a7b2e6275f3b1da88339a3cb961a3514e5332e\E\n$/ms,
                  "GOST R 34.11-2012 256bit 539 bytes")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_512 testdata3.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_512 $ARGV[0]-testdata3.dat";
     $name_re = qr/id-tc26-gost3411-12-512|md_gost12_512/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(testdata3.dat)= d5ad93fbc9ed7abc1cf28d00827a052b40bea74b04c4fd753102c1bcf9f9dad5142887f8a4cceaa0d64a0a8291592413d6adb956b99138a0023e127ff37bdf08\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-testdata3.dat)= d5ad93fbc9ed7abc1cf28d00827a052b40bea74b04c4fd753102c1bcf9f9dad5142887f8a4cceaa0d64a0a8291592413d6adb956b99138a0023e127ff37bdf08\E\n$/ms,
                  "GOST R 34.11-2012 512bit 539 bytes")) {
         diag("Command was: $cmd");
     }
 
     unlink "testdata3.dat";
-    open $F , ">","bigdata.dat";
+    open $F , ">","$ARGV[0]-bigdata.dat";
     binmode $F;
     print $F  ("121345678" x 7 . "1234567\n") x 4096,"12345\n";
     close $F;
 
-    $cmd = "openssl dgst${module_args} -md_gost94 bigdata.dat";
+    $cmd = "openssl dgst${module_args} -md_gost94 $ARGV[0]-bigdata.dat";
     $name_re = qr/id-GostR3411-94|md_gost94/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(bigdata.dat)= e5d3ac4ea3f67896c51ff919cedb9405ad771e39f0f2eab103624f9a758e506f\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-bigdata.dat)= e5d3ac4ea3f67896c51ff919cedb9405ad771e39f0f2eab103624f9a758e506f\E\n$/ms,
                  "GOST R 34.11-94 128K")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_256 bigdata.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_256 $ARGV[0]-bigdata.dat";
     $name_re = qr/id-tc26-gost3411-12-256|md_gost12_256/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(bigdata.dat)= 50e935d725d9359e5991b6b7eba8b3539fca03584d26adf4c827c982ffd49367\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-bigdata.dat)= 50e935d725d9359e5991b6b7eba8b3539fca03584d26adf4c827c982ffd49367\E\n$/ms,
                  "GOST R 34.11-2012 256bit 128K")) {
         diag("Command was: $cmd");
     }
 
-    $cmd = "openssl dgst${module_args} -md_gost12_512 bigdata.dat";
+    $cmd = "openssl dgst${module_args} -md_gost12_512 $ARGV[0]-bigdata.dat";
     $name_re = qr/id-tc26-gost3411-12-512|md_gost12_512/;
     unless (like(`$cmd`,
-                 qr/^${name_re}\Q(bigdata.dat)= 1d93645ebfbb477660f98b7d1598e37fbf3bfc8234ead26e2246e1b979e590ac46138158a692f9a0c9ac2550758b4d0d4c9fb8af5e595a16d3760c6516443f82\E\n$/ms,
+                 qr/^${name_re}\Q($ARGV[0]-bigdata.dat)= 1d93645ebfbb477660f98b7d1598e37fbf3bfc8234ead26e2246e1b979e590ac46138158a692f9a0c9ac2550758b4d0d4c9fb8af5e595a16d3760c6516443f82\E\n$/ms,
                  "GOST R 34.11-2012 512bit 128K")) {
         diag("Command was: $cmd");
     }
 
-    unlink "bigdata.dat";
+    unlink "$ARGV[0]-bigdata.dat";
 }

--- a/test/02-mac.t
+++ b/test/02-mac.t
@@ -40,11 +40,11 @@ plan(19 * scalar @test_types);
 
 # prepare data for 
 my $F;
-open $F,">","testdata.dat";
+open $F,">","$ARGV[0]-testdata.dat";
 print $F "12345670" x 128;
 close $F;
 
-open $F,">","testbig.dat";
+open $F,">","$ARGV[0]-testbig.dat";
 print $F ("12345670" x 8 . "\n") x  4096;
 close $F;
 
@@ -156,9 +156,9 @@ foreach my $test_type (@test_types) {
       my $expected;
 
       $cmd = $mac_cmd->(-mac => 'gost-mac', -key => $key,
-                        -args => $module_args, -infile => 'testdata.dat');
+                        -args => $module_args, -infile => "$ARGV[0]-testdata.dat");
       $expected = $mac_expected->(-mac => 'GOST-MAC-gost-mac',
-                                  -infile => 'testdata.dat',
+                                  -infile => "$ARGV[0]-testdata.dat",
                                   -result => '2ee8d13d');
       unless (is(`$cmd`, $expected, "GOST MAC - default size")) {
           diag("Command was: $cmd");
@@ -167,9 +167,9 @@ foreach my $test_type (@test_types) {
       my $i;
       for ($i=1;$i<=8; $i++) {
           $cmd = $mac_cmd->(-mac => 'gost-mac', -key => $key, -size => $i,
-                            -args => $module_args, -infile => 'testdata.dat');
+                            -args => $module_args, -infile => "$ARGV[0]-testdata.dat");
           $expected = $mac_expected->(-mac => 'GOST-MAC-gost-mac',
-                                      -infile => 'testdata.dat',
+                                      -infile => "$ARGV[0]-testdata.dat",
                                       -result => substr("2ee8d13dff7f037d",0,$i*2));
           unless (is(`$cmd`, $expected, "GOST MAC - size $i bytes")) {
               diag("Command was: $cmd");
@@ -179,27 +179,27 @@ foreach my $test_type (@test_types) {
 
 
       $cmd = $mac_cmd->(-mac => 'gost-mac', -key => $key,
-                        -args => $module_args, -infile => 'testbig.dat');
+                        -args => $module_args, -infile => "$ARGV[0]-testbig.dat");
       $expected = $mac_expected->(-mac => 'GOST-MAC-gost-mac',
-                                  -infile => 'testbig.dat',
+                                  -infile => "$ARGV[0]-testbig.dat",
                                   -result => '5efab81f');
       unless (is(`$cmd`, $expected, "GOST MAC - big data")) {
           diag("Command was: $cmd");
       }
 
       $cmd = $mac_cmd->(-mac => 'gost-mac-12', -key => $key,
-                        -args => $module_args, -infile => 'testdata.dat');
+                        -args => $module_args, -infile => "$ARGV[0]-testdata.dat");
       $expected = $mac_expected->(-mac => 'GOST-MAC-12-gost-mac-12',
-                                  -infile => 'testdata.dat',
+                                  -infile => "$ARGV[0]-testdata.dat",
                                   -result => 'be4453ec');
       unless (is(`$cmd`, $expected, "GOST MAC parameters 2012 - default size")) {
           diag("Command was: $cmd");
       }
       for ($i=1;$i<=8; $i++) {
           $cmd = $mac_cmd->(-mac => 'gost-mac-12', -key => $key, -size => $i,
-                            -args => $module_args, -infile => 'testdata.dat');
+                            -args => $module_args, -infile => "$ARGV[0]-testdata.dat");
           $expected = $mac_expected->(-mac => 'GOST-MAC-12-gost-mac-12',
-                                      -infile => 'testdata.dat',
+                                      -infile => "$ARGV[0]-testdata.dat",
                                       -result => substr("be4453ec1ec327be",0,$i*2));
           unless (is(`$cmd`, $expected, "GOST MAC parameters 2012 - size $i bytes")) {
               diag("Command was: $cmd");
@@ -208,5 +208,5 @@ foreach my $test_type (@test_types) {
     }
 }
 
-unlink('testdata.dat');
-unlink('testbig.dat');
+unlink("$ARGV[0]-testdata.dat");
+unlink("$ARGV[0]-testbig.dat");

--- a/test/03-encrypt.t
+++ b/test/03-encrypt.t
@@ -78,7 +78,7 @@ sub crypt_test {
     my $test_type = $p{-testtype};
     my $args = $p{-args};
     my $count = ++${$p{-count}};
-    my $result_name = "$test_type$count";
+    my $result_name = "$ARGV[0]-$test_type$count";
     open my $f, ">", "$result_name.clear";
     print $f $p{-cleartext};
     close $f;


### PR DESCRIPTION
Cmake can run tests in parallel and does so for the perl tests. These are actually the same tests twice but in "engine" and "provider" variants.

These tests contain something like the following:
- create testdata.dat
- write to it
- use the file
- unlink the file

When two of these run in parallel, a likely scenario is the file is unlinked by one while still being needed by the second.

This commit simply prefixes the filenames with "$ARGV[0]-" which is either "engine-" or "provider-". With unique names, there are no more overlaps.

PS: I had first looked for ways to disable parallel test execution (when I thought it was perl running tests in parallel rather than cmake) but found no way to do that in CMakeLists.txt, only through an environment variable or by changing the command-line invocation, both of which where far less appropriate both for distribution patches and upstreaming.