### PR TITLE
Реализация сборки Docker образов для GOST Engine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Build directories
+docker/
+build/
+bin/
+obj/
+*.tmp
+
+# Version control
+.git/
+.gitignore
+.gitmodules
+.gitattributes
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation
+*.md
+LICENSE
+INSTALL*
+CHANGELOG*
+
+# Temporary files
+*.log
+*.cache
+.cache/
+
+# OS specific
+.DS_Store
+Thumbs.db
+
+# Ignore everything except source code
+# but explicitly include what we need
+!*/
+!*.c
+!*.h
+!*.cmake
+!CMakeLists.txt
+!cmake/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,3 +133,64 @@ Value of this parameter can be either short name, defined in OpenSSL
 [RFC 4357][1].
 
 [1]:https://tools.ietf.org/html/rfc4357 "RFC 4357"
+
+
+Docker Image Building
+========================
+
+Overview
+--------
+
+This article describes how to build Docker images with a pre-built OpenSSL GOST engine for various Linux distributions.
+
+Available Images
+
+- alpine - Minimal image based on Alpine Linux
+- debian - Image based on Debian Trixie
+
+Prerequisites
+
+- Docker
+- GNU Make (optional)
+
+Building with Make
+
+To build a specific image:
+
+    $ cd docker
+    $ make alpine
+    $ make debian
+
+This will create images tagged as `gost-engine:<version>-<distro>`.
+
+Building without Make
+---------------------
+To build images manually using Docker:
+
+    $ cd docker
+    $ docker build -f docker/Dockerfile.alpine -t gost-engine:latest-alpine .
+    $ docker build -f docker/Dockerfile.debian -t gost-engine:latest-debian .
+
+Verification
+------------
+After building, verify that the images work correctly:
+
+    $ cd docker
+    $ docker run --rm gost-engine:latest-alpine openssl version
+    $ docker run --rm gost-engine:latest-alpine openssl engine -t gost
+
+The images include:
+
+- OpenSSL with GOST engine support
+- gostsum and gost12sum utilities
+- Pre-configured openssl.cnf with GOST enabled
+
+Image Contents
+--------------
+Each image contains:
+- OpenSSL with GOST engine
+- GOST cipher support
+- Command-line utilities
+- Proper CA certificates configuration
+
+The images are optimized for size and include only runtime dependencies.

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,53 @@
+FROM alpine:latest
+
+
+RUN apk update \
+    && apk add --no-cache openssl \
+    && apk add --no-cache --virtual .build-deps \
+      cmake \
+      make \
+      gcc \
+      g++ \
+      musl-dev \
+      openssl-dev \
+      git \
+      linux-headers
+
+WORKDIR /usr/local/src/engine
+
+COPY CMakeLists.txt .
+COPY *.c *.h gost.ec gostsum.1 gost12sum.1 LICENSE .
+COPY benchmark/ benchmark/
+COPY etalon/    etalon/
+COPY libprov/   libprov/
+COPY patches/   patches/
+COPY tcl_tests/ tcl_tests/
+COPY test/      test/ 
+
+# via openssl version -a
+ARG OPENSSLDIR="/etc/ssl"
+ARG ENGINESDIR="/usr/lib/engines-3"
+
+
+RUN mkdir build \
+  && cd build \
+  && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DOPENSSL_ENGINES_DIR=${ENGINESDIR} \
+    .. \
+  && cmake --build . --target install --config Release \
+  && cd bin \
+  && cp gostsum gost12sum /usr/local/bin \
+  && rm -rf /usr/local/src/engine
+
+
+WORKDIR / 
+
+# Enable engine
+COPY example.conf "${OPENSSLDIR}/gost.cnf"
+RUN sed -i "s|dynamic_path\s*=.*$|dynamic_path = ${ENGINESDIR}/gost.so|" "${OPENSSLDIR}/gost.cnf" \
+ && sed -i "11i .include ${OPENSSLDIR}/gost.cnf" "${OPENSSLDIR}/openssl.cnf"
+
+RUN apk del .build-deps \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /usr/local/src/engine

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,53 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    cmake \
+    openssl \
+    libssl-dev \
+    gcc 
+
+WORKDIR /usr/local/src/engine
+
+COPY CMakeLists.txt .
+COPY *.c *.h gost.ec gostsum.1 gost12sum.1 LICENSE .
+COPY benchmark/ benchmark/
+COPY etalon/    etalon/
+COPY libprov/   libprov/
+COPY patches/   patches/
+COPY tcl_tests/ tcl_tests/
+COPY test/      test/ 
+
+# via openssl version -a
+ARG OPENSSLDIR="/usr/lib/ssl"
+ARG ENGINESDIR="/usr/lib/x86_64-linux-gnu/engines-3"
+
+RUN mkdir build \
+  && cd build \
+  && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DOPENSSL_ENGINES_DIR=${ENGINESDIR} \
+    .. \
+  && cmake --build . --target install --config Release \
+  && cd bin \
+  && cp gostsum gost12sum /usr/local/bin \
+  && rm -rf /usr/local/src/engine
+
+
+WORKDIR /
+
+# Enable engine
+COPY example.conf "${OPENSSLDIR}/gost.cnf"
+RUN sed -i "s|dynamic_path\s*=.*$|dynamic_path = ${ENGINESDIR}/gost.so|" "${OPENSSLDIR}/gost.cnf" \
+ && sed -i "11i .include ${OPENSSLDIR}/gost.cnf" "${OPENSSLDIR}/openssl.cnf"
+
+RUN apt-get remove -y \
+      build-essential \
+      make \
+      cmake \
+      libssl-dev \
+      gcc  \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,51 @@
+
+OK           := \e[1;32mOK\e[0m
+FAIL         := \e[1;31mFAIL\e[0m
+PRINT_RESULT := echo '${OK}' || echo '${FAIL}'
+
+#
+# for git tag used tag name as version
+# else version is name of branch or "unknown" if no .git repo
+# also you can replace VERSION value using environment variables: 
+#   VERSION=latest make help
+# 
+VERSION ?= $(shell \
+	if git describe --tags --exact-match >/dev/null 2>&1; then \
+		git describe --tags --exact-match; \
+	else \
+		git branch --show-current 2>/dev/null || echo "unknown"; \
+	fi \
+)
+DOCKER_IMAGE := gost-engine
+
+RELEASES     := alpine debian 
+# rockylinux -- unsuitable version "3.2.2", but required is at least "3.4"
+
+.PHONY: help $(RELEASES)
+
+help:
+	@ echo "The GOST Engine version: $(VERSION)"
+	@ echo "Available targets: help $(RELEASES)"
+	@ echo "--"
+	@ echo "To build images use:"
+	@ for r in $(RELEASES); do \
+		echo " > make $$r => $(DOCKER_IMAGE):$(VERSION)-$$r"; \
+	done	
+
+
+update:
+	git submodule update --init
+
+
+
+$(RELEASES): update
+	docker build \
+		--file Dockerfile.$@ \
+		--tag $(DOCKER_IMAGE):$(VERSION)-$@ \
+		..
+	@ echo 
+	@ echo "\e[1;37m => Checking the OpenSSL version\e[0m"
+	@ docker run -it --rm $(DOCKER_IMAGE):$(VERSION)-$@ openssl version -v
+	@ echo "$(OK)"
+	@ echo "\e[1;37m => Checking the GOST ciphers\e[0m"
+	@ docker run -it --rm $(DOCKER_IMAGE):$(VERSION)-$@ openssl ciphers | tr ':' '\n' | grep 'GOST' && $(PRINT_RESULT)


### PR DESCRIPTION
Этот PR добавляет поддержку Docker для простой сборки и распространения GOST Engine.

**Что добавлено:**
 - docker/Dockerfile.alpine - минимальный образ на базе Alpine Linux
 - docker/Dockerfile.debian - образ на базе Debian Trixie
 - docker/Makefile - GNU make утилита для автоматической сборки и тестирования образов
 - .dockerignore - оптимизация контекста сборки Docker
 - Обновление INSTALL.md - документация по сборке через Docker

**Дополнительные комментарии:**
 - openssl используется системная, то есть устанавливается из репозитория базового образа. Пока готова поддержка двух дистрибутивов: Alpine и Debian. При желании, список образов можно расширить, но нужно подбирать образы, в которых openssl совместимы (3.4+) по версии с текущей версией engine. Собирать отдельно openssl внутри этих образов считаю не целесообразным, это совсем другая задача. 
 - Я добавил свой Makefile, так это немного упрощает многие действия. Так, команды make alpine или make debian выполняют не только сборку, но формирование имени образов исходя из названия тега в гите или по имени текущей ветки. Плюс делается автоматическая проверка: после сборки образы тестируются на корректность установки GOST движка. 
 - Я не уверен, что мне стоило обновлять INSTALL.md. Может было бы лучше составить отдельный md файл в папке docker и на него уже ссылаться из общей документации. Но пока оставил так. За вашим комментарием. 

