### PR TITLE
Fix static analysis warnings for GOST_cipher_ctx_iv_length returning -1

### DIFF
--- a/gost_cipher_ctx.c
+++ b/gost_cipher_ctx.c
@@ -1,5 +1,6 @@
 #include "gost_cipher_ctx.h"
 
+#include <assert.h>
 #include <limits.h>
 #include <stdint.h>
 #include <string.h>
@@ -260,8 +261,10 @@ int GOST_cipher_ctx_iv_length(const GOST_cipher_ctx *ctx)
                   & EVP_CIPH_CUSTOM_IV_LENGTH) != 0) {
             rv = GOST_cipher_ctx_ctrl((GOST_cipher_ctx *)ctx, EVP_CTRL_GET_IVLEN,
                                      0, &len);
-            if (rv <= 0)
-                return -1;
+            if (rv <= 0) {
+                assert(0 && "Bad cipher definition");
+                return 0;
+            }
         }
 
         ((GOST_cipher_ctx *)ctx)->iv_len = len;


### PR DESCRIPTION
This PR addresses a Coverity report about an increased number of issues caused by `GOST_cipher_ctx_iv_length` returning -1 on error (see https://github.com/gost-engine/engine/pull/523#issuecomment-4269516308). This behavior was introduced in 4e6e331a94040ff08b72492d7c87273a3db45c99.

While the implementation matches `EVP_CIPHER_CTX_iv_length`, which it replaces, returning 0 on error is safer. An assertion is added in debug builds to catch such cases.